### PR TITLE
Support custom callback to map the test results to the test points with a specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ const config: PlaywrightTestConfig = {
             displayName: 'Alex Neo',
           },
           comment: 'Playwright Test Run',
+          // the configuration ids of this test run, use https://dev.azure.com/{organization}/{project}/_apis/test/configurations to get the ids of  your project.
+          // if multiple configuration ids are used in one run a testPointMapper should be used to pick the correct one, otherwise the results are pushed to all.
+          configurationIds: [ 1 ],
         },
       } as AzureReporterOptions,
     ],
@@ -126,10 +129,25 @@ Reporter options (\* - required):
 - `environment` - Any string that will be used as environment name. Will be used as prefix for all test runs. Default: `undefined`. Example: `QA`
 - `logging` [true/false] - Enabled debug logging from reporter or not. Default: `false`.
 - `uploadAttachments` [true/false] - Uploading attachments (screenshot/video) after test ended. Default: `false`.
-- `attachmentsType` - List of attachments types that will be uploaded. Default: `['screenshot']`.
+- `attachmentsType` - List of attachments types or a RegEx to match the name of the attachment that will be uploaded. Default: `['screenshot']`
 - `isDisabled` [true/false] - Disable reporter. Default: `false`.
 - `testRunTitle` - Title of test run using to create new test run. Default: `Playwright Test Run`.
 - `testRunConfig` - Extra data to pass when Test Run creating. Read [doc](https://learn.microsoft.com/en-us/rest/api/azure/devops/test/runs/create?view=azure-devops-rest-7.1&tabs=HTTP#request-body) from more information. Default: `empty`.
+- `testPointMapper` - A callback to map the test runs to test configurations, e.g. by browser
+```
+  testPointMapper: async (testCase: TestCase, testPoints: TestPoint[]) => {
+    switch(testCase.parent.project()?.use.browserName) {
+      case 'chromium':
+        return testPoints.filter((testPoint) => testPoint.configuration.id === '3');
+      case 'firefox':
+        return testPoints.filter((testPoint) => testPoint.configuration.id === '4');
+      case 'webkit':
+        return testPoints.filter((testPoint) => testPoint.configuration.id === '5');
+      default:
+        throw new Error("invalid test configuration!");
+    }
+  }
+```
 - `publishTestResultsMode` - Mode of publishing test results. Default: `'testResult'`. Available options:
   - `testResult` - Published results of tests, at the end of each test, parallel to test run..
   - `testRun` - Published test results to test run, at the end of test run.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,6 @@
 import { PlaywrightTestConfig } from '@playwright/test';
+import { TestCase } from '@playwright/test/reporter';
+import { TestPoint } from 'azure-devops-node-api/interfaces/TestInterfaces';
 import azureConfig from './azure.config.json';
 import { AzureReporterOptions } from './src/playwright-azure-reporter';
 
@@ -27,7 +29,7 @@ const config: PlaywrightTestConfig = {
         testRunTitle: 'Playwright Test Run',
         uploadAttachments: true,
         logging: false,
-        attachmentsType: ['screenshot', 'trace'],
+        attachmentsType: ['screenshot', 'trace', /test.*/],
         publishTestResultsMode: 'testRun',
         testRunConfig: {
           configurationIds: [1],
@@ -36,6 +38,18 @@ const config: PlaywrightTestConfig = {
           },
           comment: 'Playwright Test Run',
         },
+        testPointMapper: async (testCase: TestCase, testPoints: TestPoint[]) => {
+          switch(testCase.parent.project()?.use.browserName) {
+            case 'chromium':
+              return testPoints.filter((testPoint) => testPoint.configuration.id === '3');
+            case 'firefox':
+              return testPoints.filter((testPoint) => testPoint.configuration.id === '4');
+            case 'webkit':
+              return testPoints.filter((testPoint) => testPoint.configuration.id === '5');
+            default:
+              throw new Error("invalid test configuration!");
+          }
+        }
       } as AzureReporterOptions,
     ],
   ],

--- a/src/playwright-azure-reporter.ts
+++ b/src/playwright-azure-reporter.ts
@@ -695,12 +695,17 @@ class AzureDevOpsReporter implements Reporter {
           const resultData = await this._testApi.getTestResultsByQuery(testResultsQuery, this._projectName);
 
           for (const [key, value] of withAttachmentsByTestPoint.entries()) {
-            const testResult = resultData.results?.find((result) => {result.testPoint?.id === String(key.id)});
+            const testResult = resultData.results?.find((result) => result.testPoint?.id === String(key.id));
+
+            if (!testResult) {
+              this._warning(`Test result for test point [${key.id}] is missing, attachments are not uploaded!`);
+              continue;
+            }
 
             for (const withAttachments of value) {
               await this._uploadAttachmentsFunc(
                 withAttachments.testResult,
-                testResult!.id!,
+                testResult.id!,
                 withAttachments.testCase
               );
             }

--- a/src/playwright-azure-reporter.ts
+++ b/src/playwright-azure-reporter.ts
@@ -35,12 +35,6 @@ const attachmentTypesArray = ['screenshot', 'video', 'trace'] as const;
 
 type TAttachmentType = Array<typeof attachmentTypesArray[number]>;
 type TTestRunConfig = Omit<TestInterfaces.RunCreateModel, 'name' | 'automated' | 'plan' | 'pointIds'> | undefined;
-type TTestPoint = {
-  point: number | undefined;
-  configurationId?: string;
-  configurationName?: string;
-  testCaseId: number;
-};
 type TTestResultsToBePublished = { testCase: ITestCaseExtended; testResult: TestResult };
 type TPublishTestResults = 'testResult' | 'testRun';
 
@@ -62,7 +56,7 @@ export interface AzureReporterOptions {
   uploadAttachments?: boolean | undefined;
   attachmentsType?: TAttachmentType | undefined;
   testRunConfig?: TTestRunConfig;
-  testPointMapper?: (testCase: ITestCaseExtended, testPoints: TestPoint[]) => Promise<TestPoint[] | undefined>;
+  testPointMapper?: (testCase: TestCase, testPoints: TestPoint[]) => Promise<TestPoint[] | undefined>;
 }
 
 interface TestResultsToTestRun {
@@ -140,7 +134,7 @@ class AzureDevOpsReporter implements Reporter {
   private _resolvePublishResults: () => void = () => {};
   private _rejectPublishResults: (reason: any) => void = () => {};
   private _testRunConfig: TTestRunConfig = {} as TTestRunConfig;
-  private _testPointMapper: (testCase: ITestCaseExtended, testPoints: TestPoint[]) => Promise<TestPoint[] | undefined>;
+  private _testPointMapper: (testCase: TestCase, testPoints: TestPoint[]) => Promise<TestPoint[] | undefined>;
   private _azureClientOptions = {
     allowRetries: true,
     maxRetries: 20,

--- a/src/playwright-azure-reporter.ts
+++ b/src/playwright-azure-reporter.ts
@@ -644,6 +644,7 @@ class AzureDevOpsReporter implements Reporter {
           const testPoints = value;
 
           if (testPoints && testPoints.length > 0) {
+            testCaseIds.push(...testCase.testCaseIds);
             testCaseResults.push(...testPoints.map((testPoint) => ({
               // the testPoint is the testCase + configuration, there is not need to set these
               testPoint: { id: String(testPoint.id) },

--- a/src/playwright-azure-reporter.ts
+++ b/src/playwright-azure-reporter.ts
@@ -162,10 +162,8 @@ class AzureDevOpsReporter implements Reporter {
       });
     // this is the default implementation, might be replaced by the options
     this._testPointMapper = async (testCase, testPoints) => {
-      let mappedTestPoints: TestPoint[];
-      
       if (testPoints.length > 1) {
-        this._warning("there are " + testPoints.length + " testPoints found for this testCase, you should set testRunConfig.configurationIds and/or use set a testPointMapper!");
+        this._warning(`There are ${testPoints.length} testPoints found for the test case \n ${testCase.title}, \n you should set testRunConfig.configurationIds and/or use set a testPointMapper!`);
       }
 
       return testPoints;


### PR DESCRIPTION
This is needed in the case of multiple configurations are created in Azure TestPlans.
The most common use case will be the support for multiple browsers, as shown in the example.

The testPoints passed to the testPointMapper are prefiltered to the correct TestPlan.Id, TestCase.Id and (only if the Configuration.Ids are set inside the options) the Configuration.Id. If no custom testPointMapper is set, all matching testPoints are used and a warning will be shown if there is more than one testPoints used. In the past only one of the matching points have been used.

e.g. for the testPointMapper inside the reporter options to return the correct point based on the current browser:
Do not expect for the ids to match in your instance, they are generated when the configuration is created in the Azure TestPlans UI. ([a special license is needed to get there](https://learn.microsoft.com/en-us/azure/devops/test/manual-test-permissions?view=azure-devops#access-and-licensing))
```
        testPointMapper: async (testCase: TestCase, testPoints: TestPoint[]) => {
          switch(testCase.parent.project()?.use.browserName) {
            case 'chromium':
              return testPoints.filter((testPoint) => testPoint.configuration.id === '3');
            case 'firefox':
              return testPoints.filter((testPoint) => testPoint.configuration.id === '4');
            case 'webkit':
              return testPoints.filter((testPoint) => testPoint.configuration.id === '5');
            default:
              throw new Error("invalid test configuration!");
          }
        }
```

-----------------------

Some additional notes on this change:
- the TTestPoint is removed, the call to the API only contains the TestPoint.id now, so there is no need for this type anymore. The TestPoint.id is a tuple of testCase.id, configuration.id, testPlan.id so this should be unique to assign the testresult.
- If the same testPoints are hit by different playwright TestCases the attachments will be uploaded multiple times. A warning will be logged in this case. This was the same with the old implementation if the playwright TestCase had the same TestCase IDs set, without a warning logged.
- _getTestPointIdByTCId and _getTestPointIdsByTCIds are combined now in one method, they shared most of the implementation.