### PR TITLE
add existingTestRun publishing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [1.8.0](https://github.com/alexneo2003/playwright-azure-reporter/compare/v1.7.0...v1.8.0) (2023-11-21)
+
+
+### Features
+
+* set existing test run ID ([3c2bfb3](https://github.com/alexneo2003/playwright-azure-reporter/commit/3c2bfb31fad8427dd1206202d934812a78290b27))
+
+
+
 # [1.7.0](https://github.com/alexneo2003/playwright-azure-reporter/compare/v1.7.0-beta.0...v1.7.0) (2023-11-21)
 
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,6 @@ Reporter options (\* - required):
   - `testResult` - Published results of tests, at the end of each test, parallel to test run..
   - `testRun` - Published test results to test run, at the end of test run.
     > **Note:** If you use `testRun` mode and using same test cases in different tests (yes i know it sounds funny), it will be overwritten with last test result.
-  - `existingTestRun` - Published test results to the existing test run, at the end of each test, parallel to test run. In this mode test results only added to the existing test run without its creation and completion.
-    > **Note:** If you use `existingTestRun` mode, `testRunId` should be specified.
+- `isExistingTestRun` [true/false] - Published test results to the existing test run. In this mode test results only added to the existing test run without its creation and completion.
+ > **Note:** If you use `isExistingTestRun` mode, `testRunId` should be specified.
 - `testRunId` - Id of test run. Used only for `existingTestRun` publishing mode.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # Playwright Azure Reporter
+
 ![GitHub](https://img.shields.io/github/license/alexneo2003/playwright-azure-reporter) ![npm (scoped)](https://img.shields.io/npm/v/@alex_neo/playwright-azure-reporter) ![npm](https://img.shields.io/npm/dw/@alex_neo/playwright-azure-reporter) ![npm](https://img.shields.io/npm/dt/@alex_neo/playwright-azure-reporter)
 
 ## A must read!
+
 **Since version 1.5.0 reporter allows using configurationIds to publish results for different configurations e.g. different browsers**
 **Necessarily defining `testRun.configurationIds` or/and `testPointMapper` function in reporter config, otherwise reporter will be publishing results for all configurations**
 
-
 ## How to integrate
+
 Install package
 
 ```bash
 npm install @alex_neo/playwright-azure-reporter
 ```
-or 
+
+or
+
 ```bash
 yarn add @alex_neo/playwright-azure-reporter
 ```
@@ -108,11 +112,11 @@ const config: PlaywrightTestConfig = {
             displayName: 'Alex Neo',
           },
           comment: 'Playwright Test Run',
-          // the configuration ids of this test run, use 
+          // the configuration ids of this test run, use
           // https://dev.azure.com/{organization}/{project}/_apis/test/configurations to get the ids of  your project.
-          // if multiple configuration ids are used in one run a testPointMapper should be used to pick the correct one, 
+          // if multiple configuration ids are used in one run a testPointMapper should be used to pick the correct one,
           // otherwise the results are pushed to all.
-          configurationIds: [ 1 ],
+          configurationIds: [1],
         },
       } as AzureReporterOptions,
     ],
@@ -146,6 +150,7 @@ Reporter options (\* - required):
 - `testRunTitle` - Title of test run using to create new test run. Default: `Playwright Test Run`.
 - `testRunConfig` - Extra data to pass when Test Run creating. Read [doc](https://learn.microsoft.com/en-us/rest/api/azure/devops/test/runs/create?view=azure-devops-rest-7.1&tabs=HTTP#request-body) from more information. Default: `empty`.
 - `testPointMapper` - A callback to map the test runs to test configurations, e.g. by browser
+
 ```
   testPointMapper: async (testCase: TestCase, testPoints: TestPoint[]) => {
     switch(testCase.parent.project()?.use.browserName) {
@@ -160,13 +165,18 @@ Reporter options (\* - required):
     }
   }
 ```
+
 - `publishTestResultsMode` - Mode of publishing test results. Default: `'testResult'`. Available options:
   - `testResult` - Published results of tests, at the end of each test, parallel to test run..
   - `testRun` - Published test results to test run, at the end of test run.
     > **Note:** If you use `testRun` mode and using same test cases in different tests (yes i know it sounds funny), it will be overwritten with last test result.
-- `isExistingTestRun` [true/false] - Published test results to the existing test run. In this mode test results only added to the existing test run without its creation and completion.
- > **Note:** If you use `isExistingTestRun` mode, `testRunId` should be specified.
-- `testRunId` - Id of test run. Used only for `existingTestRun` publishing mode.
+- `isExistingTestRun` [true/false] - Published test results to the existing test run. In this mode test results only added to the existing test run without its creation and completion. Default: `false`.
+  > **Note:** If you use `isExistingTestRun` mode, `testRunId` should be specified.
+- `testRunId` [number] - Id of test run. Used only for `existingTestRun` publishing mode. Also can be set by `AZURE_PW_TEST_RUN_ID` environment variable. Default: `undefined`.
+
+  > **Note:** If you set existing test run ID from reporter options and from environment variable - reporter options will be used
+
+  > **Note:** If you use `isExistingTestRun` mode, test run doesn't complete automatically. You should complete it manually.
 
 ## Usefulness
 

--- a/README.md
+++ b/README.md
@@ -164,3 +164,6 @@ Reporter options (\* - required):
   - `testResult` - Published results of tests, at the end of each test, parallel to test run..
   - `testRun` - Published test results to test run, at the end of test run.
     > **Note:** If you use `testRun` mode and using same test cases in different tests (yes i know it sounds funny), it will be overwritten with last test result.
+  - `existingTestRun` - Published test results to the existing test run, at the end of each test, parallel to test run. In this mode test results only added to the existing test run without its creation and completion.
+    > **Note:** If you use `existingTestRun` mode, `testRunId` should be specified.
+- `testRunId` - Id of test run. Used only for `existingTestRun` publishing mode.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alex_neo/playwright-azure-reporter",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Playwright Azure Reporter",
   "main": "./dist/playwright-azure-reporter.js",
   "types": "./dist/playwright-azure-reporter.d.js",

--- a/tests/reporter/reporter-existingTestRun.spec.ts
+++ b/tests/reporter/reporter-existingTestRun.spec.ts
@@ -1,0 +1,586 @@
+import path from 'path';
+
+import { setHeaders } from '../config/utils';
+import azureAreas from './assets/azure-reporter/azureAreas';
+import headers from './assets/azure-reporter/azureHeaders';
+import location from './assets/azure-reporter/azureLocationOptionsResponse.json';
+import { reporterPath } from './reporterPath';
+import { expect, test } from './test-fixtures';
+
+const TEST_OPTIONS_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'azureTestOptionsResponse.json'
+);
+const CORE_OPTIONS_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'azureCoreOptionsResponse.json'
+);
+const PROJECT_VALID_RESPONSE_PATH = path.join(__dirname, '.', 'assets', 'azure-reporter', 'projectValidResponse.json');
+const CREATE_RUN_VALID_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'createRunValidResponse.json'
+);
+const POINTS_3_VALID_RESPONSE_PATH = path.join(__dirname, '.', 'assets', 'azure-reporter', 'points3Response.json');
+const COMPLETE_RUN_VALID_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'completeRunValidResponse.json'
+);
+const TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'testRunResults3ValidResponse.json'
+);
+
+test.describe('testRun - Publish results - isExistingTestRun', () => {
+  test('isExistingTestRun without testRunId', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = { 
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testRun',
+              isExistingTestRun: true,
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async () => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.output).not.toContain('Failed request: (401)');
+    expect(result.output).not.toMatch(/azure: Using existing run (\d.*) to publish test results/);
+    expect(result.output).not.toContain('azure: AZURE_PW_TEST_RUN_ID: 150');
+    expect(result.output).toContain(
+      "azure: 'testRunId' or AZURE_PW_TEST_RUN_ID is not set for 'isExistingTestRun'=true mode. Reporting is disabled."
+    );
+    expect(result.output).not.toContain('azure: [3] foobar - failed');
+    expect(result.output).not.toContain('azure: Start publishing test results for 1 test(s)');
+    expect(result.output).not.toContain('azure: Left to publish: 0');
+    expect(result.output).not.toContain('azure: Test results published for 1 test(s)');
+    expect(result.output).not.toMatch(/azure: Run (\d.*) - Completed/);
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test('isExistingTestRun with testRunId', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = { 
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testRun',
+              isExistingTestRun: true,
+              testRunId: 150,
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async () => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.output).not.toContain('Failed request: (401)');
+    expect(result.output).toMatch(/azure: Using existing run (\d.*) to publish test results/);
+    expect(result.output).toContain('azure: AZURE_PW_TEST_RUN_ID: 150');
+    expect(result.output).not.toContain(
+      "azure: 'testRunId' or AZURE_PW_TEST_RUN_ID is not set for 'isExistingTestRun'=true mode. Reporting is disabled."
+    );
+    expect(result.output).toContain('azure: [3] foobar - failed');
+    expect(result.output).toContain('azure: Start publishing test results for 1 test(s)');
+    expect(result.output).toContain('azure: Left to publish: 0');
+    expect(result.output).toContain('azure: Test results published for 1 test(s)');
+    expect(result.output).not.toMatch(/azure: Run (\d.*) - Completed/);
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test('isExistingTestRun with AZURE_PW_TEST_RUN_ID', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = { 
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testRun',
+              isExistingTestRun: true,
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async () => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' },
+      { AZURE_PW_TEST_RUN_ID: '150' }
+    );
+
+    expect(result.output).not.toContain('Failed request: (401)');
+    expect(result.output).toMatch(/azure: Using existing run (\d.*) to publish test results/);
+    expect(result.output).toContain('azure: AZURE_PW_TEST_RUN_ID: 150');
+    expect(result.output).not.toContain(
+      "azure: 'testRunId' or AZURE_PW_TEST_RUN_ID is not set for 'isExistingTestRun'=true mode. Reporting is disabled."
+    );
+    expect(result.output).toContain('azure: [3] foobar - failed');
+    expect(result.output).toContain('azure: Start publishing test results for 1 test(s)');
+    expect(result.output).toContain('azure: Left to publish: 0');
+    expect(result.output).toContain('azure: Test results published for 1 test(s)');
+    expect(result.output).not.toMatch(/azure: Run (\d.*) - Completed/);
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+});
+
+test.describe('testResult - Publish results - isExistingTestRun', () => {
+  test('isExistingTestRun without testRunId', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = { 
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testResult',
+              isExistingTestRun: true,
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async () => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.output).not.toContain('Failed request: (401)');
+    expect(result.output).not.toMatch(/azure: Using existing run (\d.*) to publish test results/);
+    expect(result.output).not.toContain('azure: AZURE_PW_TEST_RUN_ID: 150');
+    expect(result.output).toContain(
+      "azure: 'testRunId' or AZURE_PW_TEST_RUN_ID is not set for 'isExistingTestRun'=true mode. Reporting is disabled."
+    );
+    expect(result.output).not.toContain('azure: [3] foobar - failed');
+    expect(result.output).not.toContain('azure: Start publishing test results for 1 test(s)');
+    expect(result.output).not.toContain('azure: Left to publish: 0');
+    expect(result.output).not.toContain('azure: Test results published for 1 test(s)');
+    expect(result.output).not.toMatch(/azure: Run (\d.*) - Completed/);
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test('isExistingTestRun with testRunId', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = { 
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testResult',
+              isExistingTestRun: true,
+              testRunId: 150,
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async () => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.output).not.toContain('Failed request: (401)');
+    expect(result.output).toMatch(/azure: Using existing run (\d.*) to publish test results/);
+    expect(result.output).toContain('azure: AZURE_PW_TEST_RUN_ID: 150');
+    expect(result.output).not.toContain(
+      "azure: 'testRunId' or AZURE_PW_TEST_RUN_ID is not set for 'isExistingTestRun'=true mode. Reporting is disabled."
+    );
+    expect(result.output).toContain('azure: [3] foobar - failed');
+    expect(result.output).toContain('azure: Start publishing: [3] foobar');
+    expect(result.output).toContain('azure: Result published: [3] foobar');
+    expect(result.output).not.toMatch(/azure: Run (\d.*) - Completed/);
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test('isExistingTestRun with AZURE_PW_TEST_RUN_ID', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = { 
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testResult',
+              isExistingTestRun: true,
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async () => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' },
+      { AZURE_PW_TEST_RUN_ID: '150' }
+    );
+
+    expect(result.output).not.toContain('Failed request: (401)');
+    expect(result.output).toMatch(/azure: Using existing run (\d.*) to publish test results/);
+    expect(result.output).toContain('azure: AZURE_PW_TEST_RUN_ID: 150');
+    expect(result.output).not.toContain(
+      "azure: 'testRunId' or AZURE_PW_TEST_RUN_ID is not set for 'isExistingTestRun'=true mode. Reporting is disabled."
+    );
+    expect(result.output).toContain('azure: [3] foobar - failed');
+    expect(result.output).toContain('azure: Start publishing: [3] foobar');
+    expect(result.output).toContain('azure: Result published: [3] foobar');
+    expect(result.output).not.toMatch(/azure: Run (\d.*) - Completed/);
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+});


### PR DESCRIPTION
Hi Alex,

I've added a new test results publishing mode - `existingTestRun` It enables pushing test results to the already created test run without creating and completing it. Might be useful when sharding tests between multiple machines.

