### PR TITLE
feat(auth): add support for Personal Access Token and Access Token authentication types

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ const config: PlaywrightTestConfig = {
       {
         orgUrl: 'https://dev.azure.com/your-organization-name',
         token: process.env.AZURE_TOKEN,
-        authType: 'pat', // 'pat' or 'accessToken'
+        authType: 'pat', // 'pat', 'accessToken', or 'managedIdentity'
         planId: 44,
         projectName: 'SampleSample',
         environment: 'AQA',
@@ -167,7 +167,7 @@ export default config;
 
 ## Authentication
 
-The reporter supports two authentication methods to connect to Azure DevOps:
+The reporter supports three authentication methods to connect to Azure DevOps:
 
 ### Personal Access Token (PAT) - Default
 
@@ -187,10 +187,21 @@ The reporter supports two authentication methods to connect to Azure DevOps:
 }
 ```
 
+### Azure Managed Identity
+
+```typescript
+{
+  token: 'not-used', // Token field is required but ignored for managedIdentity
+  authType: 'managedIdentity',
+  applicationIdURI: '499b84ac-1321-427f-aa17-267ca6975798/.default'
+}
+```
+
 **When to use each:**
 
 - **PAT**: Use when you have a Personal Access Token generated from Azure DevOps. Suitable for most individual use cases.
 - **Access Token**: Use when you have an OAuth access token. Suitable for applications using Azure DevOps OAuth flows or CI/CD environments with token-based authentication.
+- **Managed Identity**: Use when running in Azure environments with managed identity configured. Automatically handles authentication using Azure DefaultAzureCredential, supporting multiple auth methods like Azure CLI (`az login`), managed identity, environment variables, etc.
 
 For more detailed examples, see [Authentication Examples](tests/examples/authType-examples.md).
 
@@ -224,12 +235,15 @@ If you prefer, you can use a token with `Full access` scope, which includes all 
 
 Reporter options (\* - required):
 
-- \*`token` [string] - Azure DevOps token, you can find more information [here](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows)
+- `token` [string] - Azure DevOps token, you can find more information [here](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows). Required for `'pat'` and `'accessToken'` authTypes, not needed for `'managedIdentity'`.
 - `authType` [string] - Specifies the authentication type to use with Azure DevOps. Available options:
   - `'pat'` - Personal Access Token (default)
   - `'accessToken'` - Access Token from Azure DevOps API
+  - `'managedIdentity'` - Azure Managed Identity authentication
 
   Default: `'pat'`. For backward compatibility, existing configurations without `authType` will continue to work unchanged. See [Authentication Examples](tests/examples/authType-examples.md) for detailed usage.
+
+- `applicationIdURI` [string] - Required when `authType` is `'managedIdentity'`. Specifies the application ID URI for Azure DevOps. Typically `'499b84ac-1321-427f-aa17-267ca6975798/.default'`.
 
 - \*`orgUrl` [string] - Full url for your organization space. Example: `https://dev.azure.com/your-organization-name`
 
@@ -326,6 +340,7 @@ Reporter options (\* - required):
     - Extracted tags: `['12345']`
 
   - Test annotations:
+
     ```typescript
     test('Test case', { annotations: [{ type: 'TestCase', description: '12345' }] }, () => {
       expect(true).toBe(true);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "license": "ISC",
   "dependencies": {
+    "@azure/identity": "^4.12.0",
     "azure-devops-node-api": "^15.1.1",
     "azure-pipelines-task-lib": "^4.15.0",
     "chalk": "4.1.2",

--- a/src/playwright-azure-reporter.ts
+++ b/src/playwright-azure-reporter.ts
@@ -1,3 +1,4 @@
+import { DefaultAzureCredential } from '@azure/identity';
 import { Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 import * as azdev from 'azure-devops-node-api';
 import { WebApi } from 'azure-devops-node-api';
@@ -43,8 +44,9 @@ interface ITestCaseExtended extends TestCase {
 }
 
 export interface AzureReporterOptions {
-  token: string;
-  authType?: 'pat' | 'accessToken' | undefined;
+  token?: string;
+  authType?: 'pat' | 'accessToken' | 'managedIdentity' | undefined;
+  applicationIdURI?: string | undefined;
   planId: number;
   orgUrl: string;
   projectName: string;
@@ -145,8 +147,11 @@ class AzureDevOpsReporter implements Reporter {
   private _testRunTitle = '';
   private _uploadAttachments = false;
   private _attachmentsType: RegExp[] = [];
-  private _token: string = '';
+  private _token?: string;
   private _authType: string = 'pat';
+  private _applicationIdURI?: string;
+  private _credential?: DefaultAzureCredential;
+  private _tokenExpiresOn?: Date;
   private _runIdPromise: Promise<number | void>;
   private _resolveRunId: (value: number) => void = () => {};
   private _rejectRunId: (reason: any) => void = () => {};
@@ -255,8 +260,13 @@ class AzureDevOpsReporter implements Reporter {
       this._setIsDisable(true);
       return;
     }
-    if (!options?.token) {
+    if (!options?.token && options?.authType !== 'managedIdentity') {
       this._logger?.warn("'token' is not set. Reporting is disabled.");
+      this._setIsDisable(true);
+      return;
+    }
+    if (options?.authType === 'managedIdentity' && !options?.applicationIdURI) {
+      this._logger?.warn("'applicationIdURI' is required when authType is 'managedIdentity'. Reporting is disabled.");
       this._setIsDisable(true);
       return;
     }
@@ -291,16 +301,13 @@ class AzureDevOpsReporter implements Reporter {
     this._planId = options.planId;
     this._token = options.token;
     this._authType = options.authType || 'pat';
+    this._applicationIdURI = options.applicationIdURI;
     this._environment = options?.environment || undefined;
     this._testRunTitle =
       `${this._environment ? `[${this._environment}]:` : ''} ${options?.testRunTitle || 'Playwright Test Run'}` ||
       `${this._environment ? `[${this._environment}]:` : ''}Test plan ${this._planId}`;
     this._uploadAttachments = options?.uploadAttachments || false;
-    this._requestHandler =
-      this._authType === 'pat'
-        ? azdev.getPersonalAccessTokenHandler(this._token)
-        : azdev.getHandlerFromToken(this._token);
-    this._connection = new azdev.WebApi(this._orgUrl, this._requestHandler, this._azureClientOptions);
+    // Authentication handler and connection will be initialized in onBegin() for managedIdentity support
     this._testRunConfig = options?.testRunConfig || undefined;
     this._publishTestResultsMode = options?.publishTestResultsMode || 'testResult';
     if (options.testPointMapper) {
@@ -320,6 +327,76 @@ class AzureDevOpsReporter implements Reporter {
       this._logger?.warn(
         'This means you need to define your own testCaseIdMatcher, specifically for the "annotation" area'
       );
+    }
+  }
+
+  private async _getAuthenticationHandler(): Promise<IRequestHandler> {
+    if (this._authType === 'managedIdentity') {
+      try {
+        this._logger?.debug('Using Azure Managed Identity authentication');
+        this._credential = new DefaultAzureCredential();
+        const tokenResponse = await this._credential.getToken(this._applicationIdURI!);
+        this._token = tokenResponse.token;
+        this._tokenExpiresOn = tokenResponse.expiresOnTimestamp
+          ? new Date(tokenResponse.expiresOnTimestamp)
+          : undefined;
+        this._logger?.debug('Successfully obtained token from Azure Managed Identity');
+        if (this._tokenExpiresOn) {
+          this._logger?.debug(`Token expires on: ${this._tokenExpiresOn.toISOString()}`);
+        }
+        return azdev.getHandlerFromToken(tokenResponse.token);
+      } catch (error: any) {
+        this._logger?.error(`Failed to get token from Azure Managed Identity: ${error.message}`);
+        throw error;
+      }
+    } else if (this._authType === 'pat') {
+      if (!this._token) {
+        throw new Error('Token is required for PAT authentication');
+      }
+      return azdev.getPersonalAccessTokenHandler(this._token);
+    } else {
+      if (!this._token) {
+        throw new Error('Token is required for access token authentication');
+      }
+      return azdev.getHandlerFromToken(this._token);
+    }
+  }
+
+  private async _refreshTokenIfNeeded(): Promise<void> {
+    if (this._authType === 'managedIdentity' && this._credential) {
+      try {
+        // Check if we need to refresh the token
+        // Refresh if we don't have an expiration time or if the token expires within the next 5 minutes
+        const now = new Date();
+        const refreshThreshold = 5 * 60 * 1000; // 5 minutes in milliseconds
+        const shouldRefresh =
+          !this._tokenExpiresOn || this._tokenExpiresOn.getTime() - now.getTime() <= refreshThreshold;
+
+        if (!shouldRefresh) {
+          this._logger?.debug(`Token is still valid until ${this._tokenExpiresOn?.toISOString()}, skipping refresh`);
+          return;
+        }
+
+        this._logger?.debug('Token is expiring soon, refreshing...');
+        const tokenResponse = await this._credential.getToken(this._applicationIdURI!);
+
+        if (tokenResponse.token !== this._token) {
+          this._token = tokenResponse.token;
+          this._tokenExpiresOn = tokenResponse.expiresOnTimestamp
+            ? new Date(tokenResponse.expiresOnTimestamp)
+            : undefined;
+          this._requestHandler = azdev.getHandlerFromToken(this._token);
+          this._connection = new azdev.WebApi(this._orgUrl, this._requestHandler, this._azureClientOptions);
+          this._logger?.debug('Token refreshed successfully');
+          if (this._tokenExpiresOn) {
+            this._logger?.debug(`New token expires on: ${this._tokenExpiresOn.toISOString()}`);
+          }
+        } else {
+          this._logger?.debug('Token unchanged after refresh request');
+        }
+      } catch (error: any) {
+        this._logger?.warn(`Failed to refresh token: ${error.message}`);
+      }
     }
   }
 
@@ -356,6 +433,12 @@ class AzureDevOpsReporter implements Reporter {
   async onBegin(): Promise<void> {
     if (this._isDisabled) return;
     try {
+      // Initialize authentication handler and connection
+      if (!this._requestHandler) {
+        this._requestHandler = await this._getAuthenticationHandler();
+        this._connection = new azdev.WebApi(this._orgUrl, this._requestHandler, this._azureClientOptions);
+      }
+
       // Fetch configuration names early if configuration IDs are provided
       await this._fetchConfigurationNames();
 
@@ -405,6 +488,7 @@ class AzureDevOpsReporter implements Reporter {
     if (this._isDisabled) return;
     try {
       if (this._publishTestResultsMode === 'testResult') {
+        await this._refreshTokenIfNeeded();
         const runId = await this._runIdPromise;
         if (!runId) return;
 

--- a/tests/examples/authType-examples.md
+++ b/tests/examples/authType-examples.md
@@ -4,10 +4,11 @@ This document provides examples of how to use the new `authType` configuration o
 
 ## Overview
 
-The reporter now supports two authentication types:
+The reporter now supports three authentication types:
 
 - `pat` (Personal Access Token) - Default
 - `accessToken` (Access Token from Azure DevOps API)
+- `managedIdentity` (Azure Managed Identity)
 
 ## Examples
 
@@ -71,6 +72,26 @@ export default {
 };
 ```
 
+### Using Azure Managed Identity
+
+```typescript
+// playwright.config.ts
+export default {
+  reporter: [
+    [
+      '@alexneo2003/playwright-azure-reporter',
+      {
+        orgUrl: 'https://dev.azure.com/your-org',
+        projectName: 'your-project',
+        planId: 123,
+        authType: 'managedIdentity',
+        applicationIdURI: '499b84ac-1321-427f-aa17-267ca6975798/.default',
+      },
+    ],
+  ],
+};
+```
+
 ## When to Use Each Type
 
 ### Personal Access Token (`pat`)
@@ -84,6 +105,19 @@ export default {
 - Use when you have an OAuth access token
 - Suitable for applications using Azure DevOps OAuth flows
 - Useful in CI/CD environments with token-based authentication
+
+### Azure Managed Identity (`managedIdentity`)
+
+- Use when running in Azure environments with managed identity configured
+- Automatically handles authentication using Azure DefaultAzureCredential
+- Supports multiple authentication methods:
+  - Azure CLI (`az login`) - for local development
+  - Managed Identity - for Azure-hosted environments
+  - Environment variables
+  - Azure PowerShell
+  - Visual Studio/VS Code authentication
+- No need to manage secrets or tokens
+- Perfect for Azure DevOps pipelines running on Azure-hosted agents
 
 ## Notes
 

--- a/tests/reporter/auth-handler-creation.spec.ts
+++ b/tests/reporter/auth-handler-creation.spec.ts
@@ -4,7 +4,7 @@ import * as azdev from 'azure-devops-node-api';
 import AzureDevOpsReporter from '../../src/playwright-azure-reporter';
 
 test.describe('Authentication Handler Creation', () => {
-  test('should call getPersonalAccessTokenHandler for pat authType', () => {
+  test('should call getPersonalAccessTokenHandler for pat authType', async () => {
     // Store original function
     const originalGetPersonalAccessTokenHandler = azdev.getPersonalAccessTokenHandler;
     let handlerCreated = false;
@@ -17,7 +17,7 @@ test.describe('Authentication Handler Creation', () => {
     };
 
     try {
-      new AzureDevOpsReporter({
+      const reporter = new AzureDevOpsReporter({
         orgUrl: 'http://localhost:4000',
         projectName: 'TestProject',
         planId: 1,
@@ -26,6 +26,8 @@ test.describe('Authentication Handler Creation', () => {
         isDisabled: false,
       });
 
+      // Call the async authentication method directly
+      await (reporter as any)._getAuthenticationHandler();
       expect(handlerCreated).toBe(true);
     } finally {
       // Restore original function
@@ -33,7 +35,7 @@ test.describe('Authentication Handler Creation', () => {
     }
   });
 
-  test('should call getHandlerFromToken for accessToken authType', () => {
+  test('should call getHandlerFromToken for accessToken authType', async () => {
     // Store original function
     const originalGetHandlerFromToken = azdev.getHandlerFromToken;
     let handlerCreated = false;
@@ -46,7 +48,7 @@ test.describe('Authentication Handler Creation', () => {
     };
 
     try {
-      new AzureDevOpsReporter({
+      const reporter = new AzureDevOpsReporter({
         orgUrl: 'http://localhost:4000',
         projectName: 'TestProject',
         planId: 1,
@@ -55,6 +57,8 @@ test.describe('Authentication Handler Creation', () => {
         isDisabled: false,
       });
 
+      // Call the async authentication method directly
+      await (reporter as any)._getAuthenticationHandler();
       expect(handlerCreated).toBe(true);
     } finally {
       // Restore original function
@@ -62,7 +66,7 @@ test.describe('Authentication Handler Creation', () => {
     }
   });
 
-  test('should call getPersonalAccessTokenHandler by default', () => {
+  test('should call getPersonalAccessTokenHandler by default', async () => {
     // Store original function
     const originalGetPersonalAccessTokenHandler = azdev.getPersonalAccessTokenHandler;
     let handlerCreated = false;
@@ -75,7 +79,7 @@ test.describe('Authentication Handler Creation', () => {
     };
 
     try {
-      new AzureDevOpsReporter({
+      const reporter = new AzureDevOpsReporter({
         orgUrl: 'http://localhost:4000',
         projectName: 'TestProject',
         planId: 1,
@@ -84,6 +88,8 @@ test.describe('Authentication Handler Creation', () => {
         isDisabled: false,
       });
 
+      // Call the async authentication method directly
+      await (reporter as any)._getAuthenticationHandler();
       expect(handlerCreated).toBe(true);
     } finally {
       // Restore original function

--- a/tests/reporter/token-refresh.spec.ts
+++ b/tests/reporter/token-refresh.spec.ts
@@ -1,0 +1,327 @@
+import { expect, test } from '@playwright/test';
+import * as azdev from 'azure-devops-node-api';
+
+import AzureDevOpsReporter from '../../src/playwright-azure-reporter';
+
+test.describe('Token Refresh Tests', () => {
+  test('should not refresh token when using pat authType', async () => {
+    const reporter = new AzureDevOpsReporter({
+      orgUrl: 'http://localhost:4000',
+      projectName: 'TestProject',
+      planId: 1,
+      token: 'test-pat-token',
+      authType: 'pat',
+      isDisabled: false,
+    });
+
+    // Mock the credential to ensure it's not called
+    let credentialCalled = false;
+    (reporter as any)._credential = {
+      getToken: () => {
+        credentialCalled = true;
+        return Promise.resolve({ token: 'new-token', expiresOnTimestamp: Date.now() + 3600000 });
+      },
+    };
+
+    await (reporter as any)._refreshTokenIfNeeded();
+    expect(credentialCalled).toBe(false);
+  });
+
+  test('should not refresh token when using accessToken authType', async () => {
+    const reporter = new AzureDevOpsReporter({
+      orgUrl: 'http://localhost:4000',
+      projectName: 'TestProject',
+      planId: 1,
+      token: 'test-access-token',
+      authType: 'accessToken',
+      isDisabled: false,
+    });
+
+    // Mock the credential to ensure it's not called
+    let credentialCalled = false;
+    (reporter as any)._credential = {
+      getToken: () => {
+        credentialCalled = true;
+        return Promise.resolve({ token: 'new-token', expiresOnTimestamp: Date.now() + 3600000 });
+      },
+    };
+
+    await (reporter as any)._refreshTokenIfNeeded();
+    expect(credentialCalled).toBe(false);
+  });
+
+  test('should not refresh token when managedIdentity but no credential available', async () => {
+    const reporter = new AzureDevOpsReporter({
+      orgUrl: 'http://localhost:4000',
+      projectName: 'TestProject',
+      planId: 1,
+      authType: 'managedIdentity',
+      applicationIdURI: 'https://test.vault.azure.net',
+      isDisabled: false,
+    });
+
+    // Ensure no credential is set
+    (reporter as any)._credential = null;
+
+    // Should not throw any errors and should complete without issues
+    await (reporter as any)._refreshTokenIfNeeded();
+    expect(true).toBe(true); // Test passes if no errors thrown
+  });
+
+  test('should skip refresh when token is not close to expiring', async () => {
+    const reporter = new AzureDevOpsReporter({
+      orgUrl: 'http://localhost:4000',
+      projectName: 'TestProject',
+      planId: 1,
+      authType: 'managedIdentity',
+      applicationIdURI: 'https://test.vault.azure.net',
+      isDisabled: false,
+    });
+
+    // Set token that expires in 1 hour (not close to expiring)
+    const futureExpiry = new Date(Date.now() + 3600000); // 1 hour from now
+    (reporter as any)._tokenExpiresOn = futureExpiry;
+    (reporter as any)._token = 'current-token';
+
+    let credentialCalled = false;
+    (reporter as any)._credential = {
+      getToken: () => {
+        credentialCalled = true;
+        return Promise.resolve({ token: 'new-token', expiresOnTimestamp: Date.now() + 3600000 });
+      },
+    };
+
+    await (reporter as any)._refreshTokenIfNeeded();
+    expect(credentialCalled).toBe(false);
+  });
+
+  test('should refresh token when no expiration time is available', async () => {
+    const reporter = new AzureDevOpsReporter({
+      orgUrl: 'http://localhost:4000',
+      projectName: 'TestProject',
+      planId: 1,
+      authType: 'managedIdentity',
+      applicationIdURI: 'https://test.vault.azure.net',
+      isDisabled: false,
+    });
+
+    // Set no expiration time
+    (reporter as any)._tokenExpiresOn = null;
+    (reporter as any)._token = 'current-token';
+
+    let credentialCalled = false;
+    let newToken = 'refreshed-token';
+    let newExpiry = Date.now() + 3600000;
+
+    (reporter as any)._credential = {
+      getToken: () => {
+        credentialCalled = true;
+        return Promise.resolve({
+          token: newToken,
+          expiresOnTimestamp: newExpiry,
+        });
+      },
+    };
+
+    // Mock the WebApi creation
+    const originalGetHandlerFromToken = azdev.getHandlerFromToken;
+    let handlerCreated = false;
+    (azdev as any).getHandlerFromToken = (token: string) => {
+      handlerCreated = true;
+      expect(token).toBe(newToken);
+      return originalGetHandlerFromToken(token);
+    };
+
+    try {
+      await (reporter as any)._refreshTokenIfNeeded();
+      expect(credentialCalled).toBe(true);
+      expect(handlerCreated).toBe(true);
+      expect((reporter as any)._token).toBe(newToken);
+      expect((reporter as any)._tokenExpiresOn).toEqual(new Date(newExpiry));
+    } finally {
+      (azdev as any).getHandlerFromToken = originalGetHandlerFromToken;
+    }
+  });
+
+  test('should refresh token when close to expiring (within 5 minutes)', async () => {
+    const reporter = new AzureDevOpsReporter({
+      orgUrl: 'http://localhost:4000',
+      projectName: 'TestProject',
+      planId: 1,
+      authType: 'managedIdentity',
+      applicationIdURI: 'https://test.vault.azure.net',
+      isDisabled: false,
+    });
+
+    // Set token that expires in 2 minutes (close to expiring)
+    const soonExpiry = new Date(Date.now() + 120000); // 2 minutes from now
+    (reporter as any)._tokenExpiresOn = soonExpiry;
+    (reporter as any)._token = 'current-token';
+
+    let credentialCalled = false;
+    let newToken = 'refreshed-token';
+    let newExpiry = Date.now() + 3600000;
+
+    (reporter as any)._credential = {
+      getToken: () => {
+        credentialCalled = true;
+        return Promise.resolve({
+          token: newToken,
+          expiresOnTimestamp: newExpiry,
+        });
+      },
+    };
+
+    // Mock the WebApi creation
+    const originalGetHandlerFromToken = azdev.getHandlerFromToken;
+    let handlerCreated = false;
+    (azdev as any).getHandlerFromToken = (token: string) => {
+      handlerCreated = true;
+      expect(token).toBe(newToken);
+      return originalGetHandlerFromToken(token);
+    };
+
+    try {
+      await (reporter as any)._refreshTokenIfNeeded();
+      expect(credentialCalled).toBe(true);
+      expect(handlerCreated).toBe(true);
+      expect((reporter as any)._token).toBe(newToken);
+      expect((reporter as any)._tokenExpiresOn).toEqual(new Date(newExpiry));
+    } finally {
+      (azdev as any).getHandlerFromToken = originalGetHandlerFromToken;
+    }
+  });
+
+  test('should not update connection when token unchanged after refresh', async () => {
+    const reporter = new AzureDevOpsReporter({
+      orgUrl: 'http://localhost:4000',
+      projectName: 'TestProject',
+      planId: 1,
+      authType: 'managedIdentity',
+      applicationIdURI: 'https://test.vault.azure.net',
+      isDisabled: false,
+    });
+
+    // Set token that expires soon
+    const soonExpiry = new Date(Date.now() + 120000); // 2 minutes from now
+    const currentToken = 'current-token';
+    (reporter as any)._tokenExpiresOn = soonExpiry;
+    (reporter as any)._token = currentToken;
+
+    let credentialCalled = false;
+    (reporter as any)._credential = {
+      getToken: () => {
+        credentialCalled = true;
+        // Return same token (no refresh needed)
+        return Promise.resolve({
+          token: currentToken,
+          expiresOnTimestamp: Date.now() + 3600000,
+        });
+      },
+    };
+
+    // Mock to ensure WebApi is not recreated
+    const originalGetHandlerFromToken = azdev.getHandlerFromToken;
+    let handlerCreated = false;
+    (azdev as any).getHandlerFromToken = () => {
+      handlerCreated = true;
+      return originalGetHandlerFromToken('test');
+    };
+
+    try {
+      await (reporter as any)._refreshTokenIfNeeded();
+      expect(credentialCalled).toBe(true);
+      expect(handlerCreated).toBe(false); // Should not create new handler for same token
+      expect((reporter as any)._token).toBe(currentToken);
+    } finally {
+      (azdev as any).getHandlerFromToken = originalGetHandlerFromToken;
+    }
+  });
+
+  test('should handle token refresh errors gracefully', async () => {
+    const reporter = new AzureDevOpsReporter({
+      orgUrl: 'http://localhost:4000',
+      projectName: 'TestProject',
+      planId: 1,
+      authType: 'managedIdentity',
+      applicationIdURI: 'https://test.vault.azure.net',
+      isDisabled: false,
+    });
+
+    // Set token that expires soon
+    const soonExpiry = new Date(Date.now() + 120000); // 2 minutes from now
+    (reporter as any)._tokenExpiresOn = soonExpiry;
+    (reporter as any)._token = 'current-token';
+
+    (reporter as any)._credential = {
+      getToken: () => {
+        throw new Error('Failed to refresh token');
+      },
+    };
+
+    // Should not throw error, should handle gracefully
+    await expect((reporter as any)._refreshTokenIfNeeded()).resolves.toBeUndefined();
+  });
+
+  test('should refresh token when expiration time is exactly at threshold', async () => {
+    const reporter = new AzureDevOpsReporter({
+      orgUrl: 'http://localhost:4000',
+      projectName: 'TestProject',
+      planId: 1,
+      authType: 'managedIdentity',
+      applicationIdURI: 'https://test.vault.azure.net',
+      isDisabled: false,
+    });
+
+    // Set token that expires in exactly 5 minutes (at threshold)
+    const thresholdExpiry = new Date(Date.now() + 300000); // 5 minutes from now
+    (reporter as any)._tokenExpiresOn = thresholdExpiry;
+    (reporter as any)._token = 'current-token';
+
+    let credentialCalled = false;
+    (reporter as any)._credential = {
+      getToken: () => {
+        credentialCalled = true;
+        return Promise.resolve({
+          token: 'refreshed-token',
+          expiresOnTimestamp: Date.now() + 3600000,
+        });
+      },
+    };
+
+    await (reporter as any)._refreshTokenIfNeeded();
+    expect(credentialCalled).toBe(true);
+  });
+
+  test('should handle missing expiresOnTimestamp in token response', async () => {
+    const reporter = new AzureDevOpsReporter({
+      orgUrl: 'http://localhost:4000',
+      projectName: 'TestProject',
+      planId: 1,
+      authType: 'managedIdentity',
+      applicationIdURI: 'https://test.vault.azure.net',
+      isDisabled: false,
+    });
+
+    // Set no expiration time to force refresh
+    (reporter as any)._tokenExpiresOn = null;
+    (reporter as any)._token = 'current-token';
+
+    let credentialCalled = false;
+    (reporter as any)._credential = {
+      getToken: () => {
+        credentialCalled = true;
+        // Return token response without expiresOnTimestamp
+        return Promise.resolve({
+          token: 'new-token',
+          // No expiresOnTimestamp property
+        });
+      },
+    };
+
+    await (reporter as any)._refreshTokenIfNeeded();
+    expect(credentialCalled).toBe(true);
+    expect((reporter as any)._token).toBe('new-token');
+    expect((reporter as any)._tokenExpiresOn).toBeUndefined();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,110 @@
 # yarn lockfile v1
 
 
+"@azure/abort-controller@^2.0.0", "@azure/abort-controller@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@azure/abort-controller/-/abort-controller-2.1.2.tgz#42fe0ccab23841d9905812c58f1082d27784566d"
+  integrity sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@azure/core-auth@^1.10.0", "@azure/core-auth@^1.9.0":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.10.1.tgz#68a17fa861ebd14f6fd314055798355ef6bedf1b"
+  integrity sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-util" "^1.13.0"
+    tslib "^2.6.2"
+
+"@azure/core-client@^1.9.2":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-client/-/core-client-1.10.1.tgz#83d78f97d647ab22e6811a7a68bb4223e7a1d019"
+  integrity sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.10.0"
+    "@azure/core-rest-pipeline" "^1.22.0"
+    "@azure/core-tracing" "^1.3.0"
+    "@azure/core-util" "^1.13.0"
+    "@azure/logger" "^1.3.0"
+    tslib "^2.6.2"
+
+"@azure/core-rest-pipeline@^1.17.0", "@azure/core-rest-pipeline@^1.22.0":
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.1.tgz#f47bc02ff9a79f62e6a32aa375420b1b86dcbccd"
+  integrity sha512-UVZlVLfLyz6g3Hy7GNDpooMQonUygH7ghdiSASOOHy97fKj/mPLqgDX7aidOijn+sCMU+WU8NjlPlNTgnvbcGA==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.10.0"
+    "@azure/core-tracing" "^1.3.0"
+    "@azure/core-util" "^1.13.0"
+    "@azure/logger" "^1.3.0"
+    "@typespec/ts-http-runtime" "^0.3.0"
+    tslib "^2.6.2"
+
+"@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.3.0":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.3.1.tgz#e971045c901ea9c110616b0e1db272507781d5f6"
+  integrity sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@azure/core-util@^1.11.0", "@azure/core-util@^1.13.0":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.13.1.tgz#6dff2ff6d3c9c6430c6f4d3b3e65de531f10bafe"
+  integrity sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@typespec/ts-http-runtime" "^0.3.0"
+    tslib "^2.6.2"
+
+"@azure/identity@^4.12.0":
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/@azure/identity/-/identity-4.12.0.tgz#272e39a8742191aac0b9f5ec683984bf4d88e7cb"
+  integrity sha512-6vuh2R3Cte6SD6azNalLCjIDoryGdcvDVEV7IDRPtm5lHX5ffkDlIalaoOp5YJU08e4ipjJENel20kSMDLAcug==
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-auth" "^1.9.0"
+    "@azure/core-client" "^1.9.2"
+    "@azure/core-rest-pipeline" "^1.17.0"
+    "@azure/core-tracing" "^1.0.0"
+    "@azure/core-util" "^1.11.0"
+    "@azure/logger" "^1.0.0"
+    "@azure/msal-browser" "^4.2.0"
+    "@azure/msal-node" "^3.5.0"
+    open "^10.1.0"
+    tslib "^2.2.0"
+
+"@azure/logger@^1.0.0", "@azure/logger@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@azure/logger/-/logger-1.3.0.tgz#5501cf85d4f52630602a8cc75df76568c969a827"
+  integrity sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==
+  dependencies:
+    "@typespec/ts-http-runtime" "^0.3.0"
+    tslib "^2.6.2"
+
+"@azure/msal-browser@^4.2.0":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-4.22.1.tgz#e4c41cc0bdae7b21b7aee8c013f99beea60c9410"
+  integrity sha512-/I76rBJpt5ZVfFXk+GkKxD4w1DZEbVpNn0aQjvRgnDnTYo3L/f8Oeo3R1O9eL/ccg5j1537iRLr7UwVhwnHtyg==
+  dependencies:
+    "@azure/msal-common" "15.12.0"
+
+"@azure/msal-common@15.12.0":
+  version "15.12.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-15.12.0.tgz#5c30a05b4396e2dbbc35d27bd9bb636d44ccb00e"
+  integrity sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==
+
+"@azure/msal-node@^3.5.0":
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-3.7.3.tgz#c6c8e11c08e36a5e347af9ba7bd6e4a6b8c536a5"
+  integrity sha512-MoJxkKM/YpChfq4g2o36tElyzNUMG8mfD6u8NbuaPAsqfGpaw249khAcJYNoIOigUzRw45OjXCOrexE6ImdUxg==
+  dependencies:
+    "@azure/msal-common" "15.12.0"
+    jsonwebtoken "^9.0.0"
+    uuid "^8.3.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.26.2":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
@@ -381,6 +485,15 @@
     "@typescript-eslint/types" "8.41.0"
     eslint-visitor-keys "^4.2.1"
 
+"@typespec/ts-http-runtime@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.1.tgz#2fa94050f25b4d85d0bc8b9d97874b8d347a9173"
+  integrity sha512-SnbaqayTVFEA6/tYumdF0UmybY0KHyKwGPBXnyckFlrrKdhWFrL3a2HIPXHjht5ZOElKGcXfD2D63P36btb+ww==
+  dependencies:
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.0"
+    tslib "^2.6.2"
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -415,6 +528,11 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 ajv@^6.12.4:
   version "6.12.6"
@@ -566,6 +684,18 @@ braces@^3.0.3:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
+
+buffer-equal-constant-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
+bundle-name@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-4.1.0.tgz#f3b96b34160d6431a19d7688135af7cfb8797889"
+  integrity sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==
+  dependencies:
+    run-applescript "^7.0.0"
 
 cacheable-request@^2.1.1:
   version "2.1.4"
@@ -1086,6 +1216,19 @@ deep-is@^0.1.3:
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+default-browser-id@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-5.0.0.tgz#a1d98bf960c15082d8a3fa69e83150ccccc3af26"
+  integrity sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==
+
+default-browser@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-5.2.1.tgz#7b7ba61204ff3e425b556869ae6d3e9d9f1712cf"
+  integrity sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==
+  dependencies:
+    bundle-name "^4.1.0"
+    default-browser-id "^5.0.0"
+
 define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz"
@@ -1094,6 +1237,11 @@ define-data-property@^1.1.4:
     es-define-property "^1.0.0"
     es-errors "^1.3.0"
     gopd "^1.0.1"
+
+define-lazy-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
+  integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
 define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.2.0"
@@ -1148,6 +1296,13 @@ duplexer3@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.5.tgz#0b5e4d7bad5de8901ea4440624c8e1d20099217e"
   integrity sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 enhanced-resolve@^5.17.1:
   version "5.18.3"
@@ -1924,12 +2079,28 @@ http-cache-semantics@3.8.1:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
   integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
 
+http-proxy-agent@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
 https-proxy-agent@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
+    debug "4"
+
+https-proxy-agent@^7.0.0:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
     debug "4"
 
 husky@^9.1.7:
@@ -2091,6 +2262,11 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-docker@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
+  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
@@ -2107,6 +2283,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-inside-container@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
+  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
+  dependencies:
+    is-docker "^3.0.0"
 
 is-negative-zero@^2.0.2:
   version "2.0.2"
@@ -2209,6 +2392,13 @@ is-weakref@^1.0.2:
   dependencies:
     call-bind "^1.0.2"
 
+is-wsl@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-3.1.0.tgz#e1c657e39c10090afcbedec61720f6b924c3cbd2"
+  integrity sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==
+  dependencies:
+    is-inside-container "^1.0.0"
+
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -2301,6 +2491,39 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
+jsonwebtoken@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#65ff91f4abef1784697d40952bb1998c504caaf3"
+  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^7.5.4"
+
+jwa@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.2.tgz#16011ac6db48de7b102777e57897901520eec7b9"
+  integrity sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==
+  dependencies:
+    buffer-equal-constant-time "^1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
+
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -2381,15 +2604,50 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==
 
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
 lodash.merge@^4.0.2, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash.template@^4.0.2:
   version "4.5.0"
@@ -2747,6 +3005,16 @@ once@^1.3.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+open@^10.1.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-10.2.0.tgz#b9d855be007620e80b6fb05fac98141fe62db73c"
+  integrity sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==
+  dependencies:
+    default-browser "^5.2.1"
+    define-lazy-prop "^3.0.0"
+    is-inside-container "^1.0.0"
+    wsl-utils "^0.1.0"
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -3244,6 +3512,11 @@ reusify@^1.0.4:
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+run-applescript@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-7.1.0.tgz#2e9e54c4664ec3106c5b5630e249d3d6595c4911"
+  integrity sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
@@ -3251,7 +3524,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@^5.1.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3644,6 +3917,11 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@^2.2.0, tslib@^2.6.2:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tunnel@0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz"
@@ -3770,6 +4048,11 @@ uuid@^3.0.1:
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -3835,6 +4118,13 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+wsl-utils@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/wsl-utils/-/wsl-utils-0.1.0.tgz#8783d4df671d4d50365be2ee4c71917a0557baab"
+  integrity sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==
+  dependencies:
+    is-wsl "^3.1.0"
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION

- Add `authType` configuration option with support for 'pat' and 'accessToken' values
- Implement dynamic authentication handler selection based on authType
- Default to Personal Access Token ('pat') for backward compatibility
- Add comprehensive test coverage for authentication scenarios
- Document required Azure DevOps token scopes for both authentication types

BREAKING CHANGE: None - existing configurations continue to work unchanged

Features:
- New `authType` option in AzureReporterOptions interface
- Support for both azdev.getPersonalAccessTokenHandler and azdev.getHandlerFromToken
- Backward compatibility with existing PAT-based configurations
- Graceful handling of invalid authType values

Tests:
- 4 integration tests for authType configuration scenarios
- 3 unit tests with Azure DevOps API method mocking
- 5 authentication handler creation tests
- Complete coverage of default behavior and edge cases

Documentation:
- Updated README.md with authentication section and token scope requirements
- Created comprehensive authType-examples.md with usage examples
- Added configuration guidance for both PAT and OAuth scenarios
- Included troubleshooting section for common authentication issues

Closes #117