### PR TITLE
Mkoutroupis patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,13 +283,15 @@ Reporter options (\* - required):
   - `testResult` - Published results of tests, at the end of each test, parallel to test run..
   - `testRun` - Published test results to test run, at the end of test run.
     > **Note:** If you use `testRun` mode and using same test cases in different tests (yes i know it sounds funny), it will be overwritten with last test result.
+  - `testRunADO` - Updates existing test results in Azure DevOps test run instead of creating new results. Requires `isExistingTestRun: true` and `testRunId` to be specified.
+    > **Note:** This mode is designed for updating test results in an existing Azure DevOps test run. It will update the status and outcome of existing test results rather than creating new ones. This is useful when you want to update pre-existing test results with actual execution outcomes.
 - `isExistingTestRun` [boolean] - Published test results to the existing test run. In this mode test results only added to the existing test run without its creation and completion. Default: `false`.
-  > **Note:** If you use `isExistingTestRun` mode, `testRunId` should be specified.
-- `testRunId` [number] - Id of test run. Used only for `existingTestRun` publishing mode. Also can be set by `AZURE_PW_TEST_RUN_ID` environment variable. Default: `undefined`.
+  > **Note:** If you use `isExistingTestRun` mode or `testRunADO` mode, `testRunId` should be specified.
+- `testRunId` [number] - Id of test run. Used for `existingTestRun` publishing mode and `testRunADO` mode. Also can be set by `AZURE_PW_TEST_RUN_ID` environment variable. Default: `undefined`.
 
   > **Note:** If you set existing test run ID from reporter options and from environment variable - reporter options will be used
 
-  > **Note:** If you use `isExistingTestRun` mode, test run doesn't complete automatically. You should complete it manually.
+  > **Note:** If you use `isExistingTestRun` mode or `testRunADO` mode, test run doesn't complete automatically. You should complete it manually.
 
 - `testCaseIdMatcher` [string|RegExp|string[]|RegExp[]] - A string or a regular expression to match the name of the test case to extract the test case id. Default: `/\[([\d,\s]+)\]/`
 
@@ -445,7 +447,7 @@ Reporter options (\* - required):
 
 ## Usefulness
 
-- **AZURE_PW_TEST_RUN_ID** - Id of current test run. It will be set in environment variables after test run created. Can be accessed by `process.env.AZURE_PW_TEST_RUN_ID`. Pay attention what `publishTestResultsMode` configuration you use. If you use `testResult` mode - this variable will be set when test run created, at the start of tests execution, if you use `testRun` mode - this variable will be set when test run completed, at the end of tests execution.
+- **AZURE_PW_TEST_RUN_ID** - Id of current test run. It will be set in environment variables after test run created. Can be accessed by `process.env.AZURE_PW_TEST_RUN_ID`. Pay attention what `publishTestResultsMode` configuration you use. If you use `testResult` mode - this variable will be set when test run created, at the start of tests execution, if you use `testRun` mode - this variable will be set when test run completed, at the end of tests execution. For `testRunADO` mode, this variable will contain the existing test run ID that is being updated.
 
   > **Since version 1.10.0 you have access to `AZURE_PW_TEST_RUN_ID` environment variable in your ADO pipeline. You can get it from the Task Variables.**
 

--- a/src/playwright-azure-reporter.ts
+++ b/src/playwright-azure-reporter.ts
@@ -667,8 +667,11 @@ class AzureDevOpsReporter implements Reporter {
         this._logger?.info(`Run ${runId} - ${runUpdatedResponse.state}`, shouldForceLogs);
       } else {
         // Emit only in testRun mode to satisfy expectations; avoid noise in testResult mode with no run
-        if (this._publishTestResultsMode === 'testRun' || this._publishTestResultsMode === 'testRunADO') {
+        if (this._publishTestResultsMode === 'testRun') {
           this._logger?.info(`Run ${runId} - Skipped completion (no run created)`, true);
+        } else if(this._publishTestResultsMode === 'testRunADO' && runId && isExistingTestRun) {
+          const runUpdatedResponse = await this._testApi.updateTestRun({ state: 'Completed' }, this._projectName, runId);
+          this._logger?.info(`Run ${runId} - ${runUpdatedResponse.state}`, shouldForceLogs);
         }
       }
     } catch (error: any) {

--- a/tests/reporter/assets/azure-reporter/existingTestRunResults3-7Response.json
+++ b/tests/reporter/assets/azure-reporter/existingTestRunResults3-7Response.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": 123456,
+    "testCase": {
+      "id": "3"
+    },
+    "testPoint": {
+      "id": "1"
+    },
+    "testPlan": {
+      "id": "4"
+    },
+    "testRun": {
+      "id": "789"
+    },
+    "outcome": "NotExecuted",
+    "state": "InProgress",
+    "priority": 0,
+    "url": "http://localhost:3000/SampleSample/_apis/test/Runs/789/Results/123456",
+    "lastUpdatedBy": {
+      "displayName": "Test User",
+      "id": "test-user-id"
+    },
+    "lastUpdatedDate": "2023-01-01T00:00:00Z",
+    "project": {
+      "id": "sample-project-id"
+    }
+  },
+  {
+    "id": 123457,
+    "testCase": {
+      "id": "7"
+    },
+    "testPoint": {
+      "id": "2"
+    },
+    "testPlan": {
+      "id": "4"
+    },
+    "testRun": {
+      "id": "789"
+    },
+    "outcome": "NotExecuted",
+    "state": "InProgress",
+    "priority": 0,
+    "url": "http://localhost:3000/SampleSample/_apis/test/Runs/789/Results/123457",
+    "lastUpdatedBy": {
+      "displayName": "Test User",
+      "id": "test-user-id"
+    },
+    "lastUpdatedDate": "2023-01-01T00:00:00Z",
+    "project": {
+      "id": "sample-project-id"
+    }
+  }
+]

--- a/tests/reporter/assets/azure-reporter/existingTestRunResults3Response.json
+++ b/tests/reporter/assets/azure-reporter/existingTestRunResults3Response.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": 123456,
+    "testCase": {
+      "id": "3"
+    },
+    "testPoint": {
+      "id": "1"
+    },
+    "testPlan": {
+      "id": "4"
+    },
+    "testRun": {
+      "id": "789"
+    },
+    "outcome": "NotExecuted",
+    "state": "InProgress",
+    "priority": 0,
+    "url": "http://localhost:3000/SampleSample/_apis/test/Runs/789/Results/123456",
+    "lastUpdatedBy": {
+      "displayName": "Test User",
+      "id": "test-user-id"
+    },
+    "lastUpdatedDate": "2023-01-01T00:00:00Z",
+    "project": {
+      "id": "sample-project-id"
+    }
+  }
+]

--- a/tests/reporter/assets/azure-reporter/updatedTestRunResults3-7Response.json
+++ b/tests/reporter/assets/azure-reporter/updatedTestRunResults3-7Response.json
@@ -1,0 +1,60 @@
+[
+  {
+    "id": 123456,
+    "testCase": {
+      "id": "3"
+    },
+    "testPoint": {
+      "id": "1"
+    },
+    "testPlan": {
+      "id": "4"
+    },
+    "testRun": {
+      "id": "789"
+    },
+    "outcome": "Failed",
+    "state": "Completed",
+    "priority": 0,
+    "url": "http://localhost:3000/SampleSample/_apis/test/Runs/789/Results/123456",
+    "lastUpdatedBy": {
+      "displayName": "Test User",
+      "id": "test-user-id"
+    },
+    "lastUpdatedDate": "2023-01-01T00:00:00Z",
+    "project": {
+      "id": "sample-project-id"
+    },
+    "durationInMs": 5000,
+    "errorMessage": "[3] foobar:\n\nERROR #1:\nexpected 1 to be 0",
+    "stackTrace": "STACK #1:\n\n    at test.spec.js:3:21"
+  },
+  {
+    "id": 123457,
+    "testCase": {
+      "id": "7"
+    },
+    "testPoint": {
+      "id": "2"
+    },
+    "testPlan": {
+      "id": "4"
+    },
+    "testRun": {
+      "id": "789"
+    },
+    "outcome": "Passed",
+    "state": "Completed",
+    "priority": 0,
+    "url": "http://localhost:3000/SampleSample/_apis/test/Runs/789/Results/123457",
+    "lastUpdatedBy": {
+      "displayName": "Test User",
+      "id": "test-user-id"
+    },
+    "lastUpdatedDate": "2023-01-01T00:00:00Z",
+    "project": {
+      "id": "sample-project-id"
+    },
+    "durationInMs": 2000
+  }
+]

--- a/tests/reporter/assets/azure-reporter/updatedTestRunResults3Response.json
+++ b/tests/reporter/assets/azure-reporter/updatedTestRunResults3Response.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": 123456,
+    "testCase": {
+      "id": "3"
+    },
+    "testPoint": {
+      "id": "1"
+    },
+    "testPlan": {
+      "id": "4"
+    },
+    "testRun": {
+      "id": "789"
+    },
+    "outcome": "Failed",
+    "state": "Completed",
+    "priority": 0,
+    "url": "http://localhost:3000/SampleSample/_apis/test/Runs/789/Results/123456",
+    "lastUpdatedBy": {
+      "displayName": "Test User",
+      "id": "test-user-id"
+    },
+    "lastUpdatedDate": "2023-01-01T00:00:00Z",
+    "project": {
+      "id": "sample-project-id"
+    },
+    "durationInMs": 5000,
+    "errorMessage": "[3] foobar:\n\nERROR #1:\nexpected 1 to be 0",
+    "stackTrace": "STACK #1:\n\n    at test.spec.js:3:21"
+  }
+]

--- a/tests/reporter/reporter-publish-testRun.spec.ts
+++ b/tests/reporter/reporter-publish-testRun.spec.ts
@@ -958,6 +958,7 @@ test.describe('Publish results - testRun', () => {
 
     expect(result.output).not.toContain('Failed request: (401)');
     expect(result.output).toMatch(/azure:pw:log Using run (\d.*) to publish test results/);
+    expect(result.output).not.toContain('No existing test case results found for test cases');
     expect(result.output).toContain(
       'azure:pw:log Start publishing test results for 125 test(s)\nazure:pw:log Starting to uploading attachments for 5 testpoint(s)\nazure:pw:log Uploading attachments for test: [10] foobar\nazure:pw:log Uploaded attachments'
     );

--- a/tests/reporter/reporter-publish-testRunADO.spec.ts
+++ b/tests/reporter/reporter-publish-testRunADO.spec.ts
@@ -1,0 +1,571 @@
+import path from 'path';
+
+import { setHeaders } from '../config/utils';
+import azureAreas from './assets/azure-reporter/azureAreas';
+import headers from './assets/azure-reporter/azureHeaders';
+import location from './assets/azure-reporter/azureLocationOptionsResponse.json';
+import { reporterPath } from './reporterPath';
+import { expect, test } from './test-fixtures';
+
+const TEST_OPTIONS_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'azureTestOptionsResponse.json'
+);
+const CORE_OPTIONS_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'azureCoreOptionsResponse.json'
+);
+const PROJECT_VALID_RESPONSE_PATH = path.join(__dirname, '.', 'assets', 'azure-reporter', 'projectValidResponse.json');
+const POINTS_3_VALID_RESPONSE_PATH = path.join(__dirname, '.', 'assets', 'azure-reporter', 'points3Response.json');
+const EXISTING_TEST_RUN_RESULTS_3_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'existingTestRunResults3Response.json'
+);
+const UPDATED_TEST_RUN_RESULTS_3_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'updatedTestRunResults3Response.json'
+);
+
+// Mock response for pagination test - simulates large test run with multiple pages
+function createMockPaginatedTestResults(skip: number, top: number, testCaseId: number, totalResults = 500) {
+  const results: any[] = [];
+  const startId = skip + 1;
+  const endId = Math.min(skip + top, totalResults);
+
+  // Only return results if we haven't exceeded the total
+  if (skip < totalResults) {
+    for (let i = startId; i <= endId; i++) {
+      results.push({
+        id: 123000 + i,
+        testCase: {
+          id: testCaseId.toString(),
+        },
+        testPoint: {
+          id: (1000 + i).toString(),
+        },
+        testPlan: {
+          id: '4',
+        },
+        testRun: {
+          id: '999',
+        },
+        outcome: 'NotExecuted',
+        state: 'InProgress',
+        priority: 0,
+        url: `http://localhost:3000/SampleSample/_apis/test/Runs/999/Results/${123000 + i}`,
+        lastUpdatedBy: {
+          displayName: 'Test User',
+          id: 'test-user-id',
+        },
+        lastUpdatedDate: '2023-01-01T00:00:00Z',
+        project: {
+          id: 'sample-project-id',
+        },
+      });
+    }
+  }
+
+  return results;
+}
+
+test.describe('Publish results - testRunADO', () => {
+  test('testRunADO mode requires existing test run', async ({ runInlineTest }) => {
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://azure.devops.com',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testRunADO',
+              isExistingTestRun: true,
+              // Missing testRunId - should fail validation
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async ({}) => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.output).toContain(
+      "azure:pw:warn 'testRunADO' mode requires both 'testRunId' and 'isExistingTestRun=true' to be set. Reporting is disabled."
+    );
+    // When reporter is disabled, it doesn't log test results
+    expect(result.output).not.toContain('azure:pw:log [3] foobar - failed');
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test('testRunADO mode requires testRunId and isExistingTestRun=true', async ({ runInlineTest }) => {
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://azure.devops.com',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testRunADO',
+              // Missing isExistingTestRun - should fail validation
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async ({}) => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.output).toContain(
+      "azure:pw:warn 'testRunADO' mode requires both 'testRunId' and 'isExistingTestRun=true' to be set. Reporting is disabled."
+    );
+    // When reporter is disabled, it doesn't log test results
+    expect(result.output).not.toContain('azure:pw:log [3] foobar - failed');
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test('testRunADO mode updates existing test result successfully', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    // Mock existing test results in the test run - handle both with and without query parameters
+    server.setRoute('/SampleSample/_apis/test/Runs/789/Results?%24skip=0&%24top=200', (req, res) => {
+      const method = req.method;
+      setHeaders(res, headers);
+
+      if (method === 'GET') {
+        // Return existing test results - this should work with pagination parameters
+        server.serveFile(req, res, EXISTING_TEST_RUN_RESULTS_3_RESPONSE_PATH);
+      }
+    });
+    server.setRoute('/SampleSample/_apis/test/Runs/789/Results', (req, res) => {
+      const method = req.method;
+      setHeaders(res, headers);
+
+      if (method === 'PATCH') {
+        // Return updated test results after update
+        server.serveFile(req, res, UPDATED_TEST_RUN_RESULTS_3_RESPONSE_PATH);
+      }
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testRunADO',
+              isExistingTestRun: true,
+              testRunId: 789,
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async ({}) => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' },
+      {
+        AZUREPWDEBUG: '1',
+      }
+    );
+
+    expect(result.output).not.toContain('Failed request: (401)');
+    expect(result.output).toContain('azure:pw:log [3] foobar - failed');
+    expect(result.output).not.toContain('azure:pw:warn No test points found for test case');
+    expect(result.output).toContain('azure:pw:log Start publishing test results for 1 test(s)');
+    expect(result.output).toContain('azure:pw:log Test results published for 1 test(s), 1 test point(s)');
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test('testRunADO mode warns when no existing test results found', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    // Mock empty existing test results in the test run
+    server.setRoute('/SampleSample/_apis/test/Runs/789/Results?%24skip=0&%24top=200', (req, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify([])); // Empty results array
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testRunADO',
+              isExistingTestRun: true,
+              testRunId: 789,
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async ({}) => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.output).not.toContain('Failed request: (401)');
+    expect(result.output).toContain('azure:pw:log [3] foobar - failed');
+    expect(result.output).toContain('azure:pw:log Start publishing test results for 1 test(s)');
+    // In testRunADO mode, when no test points are found, it logs a different message
+    expect(result.output).toContain('azure:pw:warn No test points found for test case [3] associated with test plan 4');
+    expect(result.output).toContain('azure:pw:log Test results published for 0 test(s), 0 test point(s)');
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test('testRunADO mode does not complete test run automatically', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/789/Results?%24skip=0&%24top=200', (req, res) => {
+      const method = req.method;
+      setHeaders(res, headers);
+
+      if (method === 'GET') {
+        server.serveFile(req, res, EXISTING_TEST_RUN_RESULTS_3_RESPONSE_PATH);
+      }
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/789/Results', (req, res) => {
+      const method = req.method;
+      setHeaders(res, headers);
+
+      if (method === 'PATCH') {
+        // Return updated test results after update
+        server.serveFile(req, res, UPDATED_TEST_RUN_RESULTS_3_RESPONSE_PATH);
+      }
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testRunADO',
+              isExistingTestRun: true,
+              testRunId: 789,
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async ({}) => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' },
+      {
+        AZUREPWDEBUG: '1',
+      }
+    );
+
+    expect(result.output).not.toContain('Failed request: (401)');
+    expect(result.output).toContain('azure:pw:log [3] foobar - failed');
+    expect(result.output).not.toContain('azure:pw:warn No test points found for test case');
+    expect(result.output).toContain('azure:pw:log Start publishing test results for 1 test(s)');
+    expect(result.output).toContain('azure:pw:log Test results published for 1 test(s), 1 test point(s)');
+    // Should NOT contain test run completion message
+    expect(result.output).not.toContain('Run 789 - Completed');
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test('testRunADO mode handles paginated responses with >200 test results', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    // Mock paginated test results responses
+    // First call (skip=0, top=200) - returns full page
+    server.setRoute('/SampleSample/_apis/test/Runs/999/Results?%24skip=0&%24top=200', (req, res) => {
+      setHeaders(res, headers);
+      const paginatedResults = createMockPaginatedTestResults(0, 200, 3, 500);
+      res.end(JSON.stringify(paginatedResults));
+    });
+
+    // Second call (skip=200, top=200) - returns second page
+    server.setRoute('/SampleSample/_apis/test/Runs/999/Results?%24skip=200&%24top=200', (req, res) => {
+      setHeaders(res, headers);
+      const paginatedResults = createMockPaginatedTestResults(200, 200, 3, 500);
+      res.end(JSON.stringify(paginatedResults));
+    });
+
+    // Third call (skip=400, top=200) - returns remaining results
+    server.setRoute('/SampleSample/_apis/test/Runs/999/Results?%24skip=400&%24top=200', (req, res) => {
+      setHeaders(res, headers);
+      const paginatedResults = createMockPaginatedTestResults(400, 200, 3, 500);
+      res.end(JSON.stringify(paginatedResults));
+    });
+
+    // Fourth call (skip=500, top=200) - returns empty array (no more results)
+    server.setRoute('/SampleSample/_apis/test/Runs/999/Results?%24skip=500&%24top=200', (req, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify([]));
+    });
+
+    // Handle PATCH request to update test results - return the first result that matches
+    server.setRoute('/SampleSample/_apis/test/Runs/999/Results', (req, res) => {
+      const method = req.method;
+      setHeaders(res, headers);
+
+      if (method === 'PATCH') {
+        // Create a mock updated result based on the first test result
+        const updatedResult = [
+          {
+            id: 123456,
+            testCase: {
+              id: '3',
+            },
+            testPoint: {
+              id: '1',
+            },
+            testPlan: {
+              id: '4',
+            },
+            testRun: {
+              id: '999',
+            },
+            outcome: 'Failed',
+            state: 'Completed',
+            priority: 0,
+            url: 'http://localhost:3000/SampleSample/_apis/test/Runs/999/Results/123456',
+            lastUpdatedBy: {
+              displayName: 'Test User',
+              id: 'test-user-id',
+            },
+            lastUpdatedDate: '2023-01-01T00:00:00Z',
+            project: {
+              id: 'sample-project-id',
+            },
+          },
+        ];
+        res.end(JSON.stringify(updatedResult));
+      }
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testRunADO',
+              isExistingTestRun: true,
+              testRunId: 999,
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] foobar', async ({}) => {
+          expect(1).toBe(0);
+        });
+      `,
+      },
+      { reporter: '' },
+      {
+        AZUREPWDEBUG: '1',
+      }
+    );
+
+    expect(result.output).not.toContain('Failed request: (401)');
+    expect(result.output).toContain('azure:pw:log [3] foobar - failed');
+    expect(result.output).toContain('azure:pw:log Start publishing test results for 1 test(s)');
+    // Verify pagination is working - should see multiple fetch operations
+    expect(result.output).toContain('azure:pw:log Fetching test results from existing test run (skip: 0, top: 200)');
+    expect(result.output).toContain(
+      'azure:pw:log Fetching next test results from existing test run (skip: 200, top: 200)'
+    );
+    expect(result.output).toContain(
+      'azure:pw:log Fetching next test results from existing test run (skip: 400, top: 200)'
+    );
+    // Verify that it fetched all 500 test results (this proves pagination worked)
+    expect(result.output).toContain('azure:pw:debug [_publishTestRunResults] ExistingTestCaseResultsForRun: 500');
+    // Should NOT contain test run completion message
+    expect(result.output).not.toContain('Run 999 - Completed');
+    expect(result.exitCode).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+});


### PR DESCRIPTION
Update to the version **1.15.1-pr123.main.21f0929**

Regarding the changes in this PR and the expectation behind them, it is to run automated tests from test plans. In Azure DevOps, there is a way to run automated tests by doing 2 things. First, [associate automated tests with the Azure DevOps test cases](https://learn.microsoft.com/en-us/azure/devops/test/associate-automated-test-with-test-case?view=azure-devops). Afterwards, a [classic release pipeline should be created and associated with a Azure DevOps plan](https://learn.microsoft.com/en-us/azure/devops/test/run-automated-tests-from-test-hub?view=azure-devops). Once these steps are completed, the user has the ability to go to Azure DevOps test plan/test suite, select the desired test cases and click the button to run. This triggers the associated classic release pipeline, creating a test run for the selected test cases and reports back the outcome of the automation.
This works fine with .NET test runners and VSTest applications. However, there is no support for NodeJS.

Since your Playwright plugin integrates with Azure DevOps by creating test runs and test results, I thought it would be a good opportunity to extend it a bit in order to have the described functionality while using Playwright. Specifically, my changes are related to step 2 from the process described above. The classic release pipeline, executes npx playwright test --grep '(?=.@testcaseid) | (?=.@testcaseid)' as you would expect. By passing to the playwright.config, the token, the relevant testRunId, the relevant planId and publishTestResultsMode=testRunADO, the plugin at the end of the execution (onEnd) doesn't create a new test run, gets the existing one, updates the existing test results based on the outcome and **completes** the run. The changes don't affect the current functionality.