### PR TITLE
fix(reporter): preserve TestCase getter properties when creating extended test cases

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ module.exports = [
       'dist/**',
       'node_modules/**',
       'test-results/**',
+      'playwright-report/**',
       '**/.DS_Store',
       '**/coverage/**',
       '**/*.min.js',

--- a/src/playwright-azure-reporter.ts
+++ b/src/playwright-azure-reporter.ts
@@ -542,11 +542,11 @@ class AzureDevOpsReporter implements Reporter {
         this._logTestItem(test, testResult);
         const caseIds = this._getCaseIds(test);
         if (!caseIds || !caseIds.length) return;
-        const testCase: ITestCaseExtended = {
-          ...test,
-          testAlias: `${shortID()} - ${test.title}`,
-          testCaseIds: caseIds,
-        };
+        const testCase: ITestCaseExtended = this._createExtendedTestCase(
+          test,
+          `${shortID()} - ${test.title}`,
+          caseIds
+        );
         this._testResultsToBePublished.push({ testCase: testCase, testResult });
       }
     } catch (error: any) {
@@ -703,6 +703,24 @@ class AzureDevOpsReporter implements Reporter {
 
   printsToStdio(): boolean {
     return true;
+  }
+
+  /**
+   * Creates an ITestCaseExtended object while preserving all getters and methods from TestCase interface
+   */
+  private _createExtendedTestCase(test: TestCase, testAlias: string, testCaseIds: string[]): ITestCaseExtended {
+    return {
+      // Spread all enumerable properties
+      ...test,
+      // Explicitly preserve getters and methods
+      ok: test.ok.bind(test),
+      outcome: test.outcome.bind(test),
+      titlePath: test.titlePath.bind(test),
+      tags: test.tags,
+      // Add extended properties
+      testAlias: testAlias,
+      testCaseIds: testCaseIds,
+    };
   }
 
   private _anonymizeString(str: string | undefined): string {
@@ -1485,11 +1503,11 @@ class AzureDevOpsReporter implements Reporter {
     const caseIds = this._getCaseIds(test);
     if (!caseIds || !caseIds.length) return;
 
-    const testCase: ITestCaseExtended = {
-      ...test,
-      testAlias: `${shortID()} - ${test.title}`,
-      testCaseIds: caseIds,
-    };
+    const testCase: ITestCaseExtended = this._createExtendedTestCase(
+      test,
+      `${shortID()} - ${test.title}`,
+      caseIds
+    );
 
     this._testsAliasToBePublished.push(testCase.testAlias);
 

--- a/tests/reporter/reporter-constructor.spec.ts
+++ b/tests/reporter/reporter-constructor.spec.ts
@@ -814,7 +814,7 @@ test.describe('Test Case ID matcher in title and tag section', () => {
           isDisabled: false,
           testCaseIdMatcher: testCaseIdMatcher.testCaseIdMatcher,
         });
-      } catch (error) {
+      } catch (error: any) {
         expect(error.message).toContain('Invalid testCaseIdMatcher. Must be a string or RegExp. Actual: 3432');
       }
     });

--- a/tests/reporter/reporter-testPointMapper.spec.ts
+++ b/tests/reporter/reporter-testPointMapper.spec.ts
@@ -1,0 +1,431 @@
+import path from 'path';
+
+import { setHeaders } from '../config/utils';
+import azureAreas from './assets/azure-reporter/azureAreas';
+import headers from './assets/azure-reporter/azureHeaders';
+import location from './assets/azure-reporter/azureLocationOptionsResponse.json';
+import { reporterPath } from './reporterPath';
+import { expect, test } from './test-fixtures';
+
+const TEST_OPTIONS_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'azureTestOptionsResponse.json'
+);
+const CORE_OPTIONS_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'azureCoreOptionsResponse.json'
+);
+const PROJECT_VALID_RESPONSE_PATH = path.join(__dirname, '.', 'assets', 'azure-reporter', 'projectValidResponse.json');
+const CREATE_RUN_VALID_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'createRunValidResponse.json'
+);
+const POINTS_3_VALID_RESPONSE_PATH = path.join(__dirname, '.', 'assets', 'azure-reporter', 'points3Response.json');
+const COMPLETE_RUN_VALID_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'completeRunValidResponse.json'
+);
+const TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH = path.join(
+  __dirname,
+  '.',
+  'assets',
+  'azure-reporter',
+  'testRunResults3ValidResponse.json'
+);
+
+test.describe('TestPointMapper functionality', () => {
+  test('testPointMapper can access testCase.tags without undefined errors', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH);
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              testPointMapper: async (testCase, testPoints) => {
+                // Log the testCase properties to verify tags is accessible
+                console.log('TESTCASE_PROPS:', JSON.stringify({
+                  title: testCase.title,
+                  tags: testCase.tags,
+                  hasTagsProperty: testCase.tags !== undefined,
+                  tagsType: typeof testCase.tags,
+                  tagsLength: testCase.tags ? testCase.tags.length : 0
+                }));
+                
+                // Validate that testCase.tags is accessible and not undefined
+                if (!testCase.tags) {
+                  throw new Error('testCase.tags is undefined - this should not happen after the fix');
+                }
+                
+                // Test the exact logic from the user's example
+                const tag = testCase.tags.map((t) => t.toLowerCase());
+                const tagOne = tag.includes("@tagone");
+                const tagTwo = tag.includes("@tagtwo");
+
+                console.log('TESTPOINTMAPPER_FILTERING:', JSON.stringify({
+                  allTags: tag,
+                  hasTagOne: tagOne,
+                  hasTagTwo: tagTwo
+                }));
+
+                if (tagOne && tagTwo) {
+                  const filtered = testPoints.filter(
+                    (tp) => tp.configuration.id === "3" || tp.configuration.id === "17"
+                  );
+                  console.log('TESTPOINTMAPPER_RESULT: both tags - filtered', filtered.length, 'points');
+                  return filtered;
+                } else if (tagOne) {
+                  const filtered = testPoints.filter((tp) => tp.configuration.id === "3");
+                  console.log('TESTPOINTMAPPER_RESULT: tagOne only - filtered', filtered.length, 'points');
+                  return filtered;
+                } else if (tagTwo) {
+                  const filtered = testPoints.filter((tp) => tp.configuration.id === "17");
+                  console.log('TESTPOINTMAPPER_RESULT: tagTwo only - filtered', filtered.length, 'points');
+                  return filtered;
+                } else {
+                  console.log('TESTPOINTMAPPER_RESULT: no matching tags - returning all', testPoints.length, 'points');
+                  return testPoints;
+                }
+              }
+            }]
+          ]
+        };
+      `,
+        'a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[3] Test with both tags', { tag: ['@tagOne', '@tagTwo'] }, async () => {
+          expect(1).toBe(1);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.passed).toBe(1);
+
+    // Verify that testCase.tags is accessible and logged correctly
+    expect(result.output).toContain('TESTCASE_PROPS:');
+    expect(result.output).toContain('"hasTagsProperty":true');
+    expect(result.output).toContain('"tagsType":"object"');
+    expect(result.output).toContain('"tags":["@tagOne","@tagTwo"]');
+    
+    // Verify filtering logic worked correctly
+    expect(result.output).toContain('TESTPOINTMAPPER_FILTERING:');
+    expect(result.output).toContain('"hasTagOne":true');
+    expect(result.output).toContain('"hasTagTwo":true');
+
+    // Verify no undefined errors occurred
+    expect(result.output).not.toContain('testCase.tags is undefined');
+    expect(result.output).not.toContain('Cannot read properties of undefined');
+    expect(result.output).not.toContain('TypeError');
+  });
+
+  test('testPointMapper handles different tag combinations correctly', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH);
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              testPointMapper: async (testCase, testPoints) => {
+                // Test tag filtering by configuration based on testCase.tags
+                const tags = testCase.tags || [];
+                const tagOne = tags.some(tag => tag.toLowerCase() === '@tagone');
+                const tagTwo = tags.some(tag => tag.toLowerCase() === '@tagtwo');
+                
+                console.log('TESTCASE_INFO:', JSON.stringify({
+                  title: testCase.title,
+                  allTags: tags,
+                  hasTagOne: tagOne,
+                  hasTagTwo: tagTwo,
+                  testPointsCount: testPoints.length
+                }));
+
+                if (tagOne && tagTwo) {
+                  // Return test points for configurations 3 and 17
+                  return testPoints.filter(tp => 
+                    tp.configuration.id === "3" || tp.configuration.id === "17"
+                  );
+                } else if (tagOne) {
+                  // Return test points for configuration 3 only
+                  return testPoints.filter(tp => tp.configuration.id === "3");
+                } else if (tagTwo) {
+                  // Return test points for configuration 17 only
+                  return testPoints.filter(tp => tp.configuration.id === "17");
+                } else {
+                  // Return all test points for other tags
+                  return testPoints;
+                }
+              }
+            }]
+          ]
+        };
+      `,
+        'multiple.spec.js': `
+        import { test, expect } from '@playwright/test';
+        
+        // Test with only tagOne - should filter to configuration 3
+        test('[3] Test with tagOne only', { tag: ['@tagOne'] }, async () => {
+          expect(1).toBe(1);
+        });
+        
+        // Test with only tagTwo - should filter to configuration 17
+        test('[3] Test with tagTwo only', { tag: ['@tagTwo'] }, async () => {
+          expect(1).toBe(1);
+        });
+        
+        // Test with no relevant tags - should return all test points
+        test('[3] Test with other tags', { tag: ['@otherTag'] }, async () => {
+          expect(1).toBe(1);
+        });
+        `
+      },
+      { reporter: '' }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.passed).toBe(3);
+
+    // Verify that filtering worked based on tags
+    expect(result.output).toContain('TESTCASE_INFO:');
+    expect(result.output).toContain('"hasTagOne":true');
+    expect(result.output).toContain('"hasTagTwo":true');
+    
+    // Verify that tags are properly accessible for all test cases
+    expect(result.output).toContain('"allTags":["@tagOne"]');
+    expect(result.output).toContain('"allTags":["@tagTwo"]');
+    expect(result.output).toContain('"allTags":["@otherTag"]');
+    
+    // Verify that tags are properly accessible
+    expect(result.output).not.toContain('Cannot read properties of undefined');
+    expect(result.output).not.toContain('TypeError');
+  });
+
+  test('testPointMapper handles edge cases - empty tags, null tags', async ({ runInlineTest, server }) => {
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_3_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_RUN_RESULTS_3_VALID_RESPONSE_PATH);
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              testPointMapper: async (testCase, testPoints) => {
+                // Test edge cases: empty tags, null tags, undefined tags
+                console.log('EDGE_CASE_TEST:', JSON.stringify({
+                  title: testCase.title,
+                  tags: testCase.tags,
+                  tagsIsArray: Array.isArray(testCase.tags),
+                  tagsLength: testCase.tags ? testCase.tags.length : 'N/A',
+                  hasOwnProperty: testCase.hasOwnProperty('tags')
+                }));
+                
+                // Safe access to tags with defensive checks
+                const tags = testCase.tags || [];
+                const safeTagCheck = tags.length > 0 ? tags[0] : 'no-tags';
+                
+                console.log('SAFE_TAG_ACCESS:', JSON.stringify({
+                  firstTag: safeTagCheck,
+                  canMapTags: tags.length > 0,
+                  allTagsLowercase: tags.map(t => t.toLowerCase())
+                }));
+                
+                return testPoints; // Return all points for edge case testing
+              }
+            }]
+          ]
+        };
+      `,
+        'edge.spec.js': `
+        import { test, expect } from '@playwright/test';
+        
+        // Test with no tags
+        test('[3] Test with no tags', async () => {
+          expect(1).toBe(1);
+        });
+        
+        // Test with empty tag array  
+        test('[3] Test with empty tags', { tag: [] }, async () => {
+          expect(1).toBe(1);
+        });
+        `
+      },
+      { reporter: '' }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.passed).toBe(2);
+
+    // Verify edge case handling
+    expect(result.output).toContain('EDGE_CASE_TEST:');
+    expect(result.output).toContain('SAFE_TAG_ACCESS:');
+    expect(result.output).toContain('"tagsIsArray":true');
+    
+    // Verify no undefined errors in edge cases
+    expect(result.output).not.toContain('Cannot read properties of undefined');
+    expect(result.output).not.toContain('TypeError');
+  });
+});

--- a/tests/reporter/reporter-utils.spec.ts
+++ b/tests/reporter/reporter-utils.spec.ts
@@ -1,3 +1,6 @@
+import { TestCase } from '@playwright/test/reporter';
+
+import AzureDevOpsReporter from '../../dist/playwright-azure-reporter';
 import { getExtensionFromContentType, getExtensionFromFilename, getMimeTypeFromFilename } from '../../src/utils';
 import { expect, test } from './test-fixtures';
 
@@ -38,5 +41,188 @@ test.describe('Reporter utils', () => {
     expect(getExtensionFromContentType('application/json')).toBe('json');
     expect(getExtensionFromContentType('application/pdf')).toBe('pdf');
     expect(getExtensionFromContentType('')).toBe('bin');
+  });
+});
+
+test.describe('Reporter TestCase Extension', () => {
+  test('_createExtendedTestCase preserves all TestCase interface properties', async () => {
+    // Create a mock TestCase object with all interface properties
+    const mockTestCase: TestCase & { _tags: string[]; _grepBaseTitlePath: () => string[] } = {
+      // Basic properties
+      id: 'test-id-123',
+      title: 'Test with tags @[123], @tagOne, @tagTwo',
+      expectedStatus: 'passed',
+      timeout: 30000,
+      annotations: [
+        { type: 'slow', description: 'This test is slow' },
+        { type: 'skip', description: 'Skip in CI' }
+      ],
+      retries: 2,
+      repeatEachIndex: 0,
+      results: [],
+      type: 'test' as const,
+      location: { file: '/test/file.spec.ts', line: 10, column: 5 },
+      parent: {} as any, // Mock suite
+      
+      // Mock private properties and methods that the getter uses
+      _tags: ['@tagOne', '@tagTwo'],
+      _grepBaseTitlePath: function() { return ['Suite', 'Nested Suite', this.title]; },
+      
+      // Mock getter: tags (matching actual Playwright implementation)
+      get tags(): string[] {
+        const titleTags = this._grepBaseTitlePath().join(' ').match(/@[\S]+/g) || [];
+        return [
+          ...titleTags,
+          ...this._tags,
+        ];
+      },
+      
+      // Mock methods
+      ok: function() { return true; },
+      outcome: function() { return 'expected' as const; },
+      titlePath: function() { return ['Suite', 'Nested Suite', this.title]; }
+    };
+
+    // Create a minimal reporter instance to access the private method
+    const reporterOptions = {
+      orgUrl: 'https://dev.azure.com/test',
+      projectName: 'test-project',
+      planId: 123,
+      token: 'test-token',
+      isDisabled: true // Disable to avoid actual API calls
+    };
+    
+    const reporter = new AzureDevOpsReporter(reporterOptions);
+    
+    // Access the private method using type assertion
+    const createExtendedTestCase = (reporter as any)._createExtendedTestCase.bind(reporter);
+    
+    // Test the method
+    const testAlias = 'alias-123 - Test with tags';
+    const testCaseIds = ['123', '456'];
+    
+    const extendedTestCase = createExtendedTestCase(mockTestCase, testAlias, testCaseIds);
+    
+    // Verify all original properties are preserved
+    expect(extendedTestCase.id).toBe('test-id-123');
+    expect(extendedTestCase.title).toBe('Test with tags @[123], @tagOne, @tagTwo');
+    expect(extendedTestCase.expectedStatus).toBe('passed');
+    expect(extendedTestCase.timeout).toBe(30000);
+    expect(extendedTestCase.annotations).toEqual([
+      { type: 'slow', description: 'This test is slow' },
+      { type: 'skip', description: 'Skip in CI' }
+    ]);
+    expect(extendedTestCase.retries).toBe(2);
+    expect(extendedTestCase.repeatEachIndex).toBe(0);
+    expect(extendedTestCase.results).toEqual([]);
+    expect(extendedTestCase.type).toBe('test');
+    expect(extendedTestCase.location).toEqual({ file: '/test/file.spec.ts', line: 10, column: 5 });
+    
+    // Verify getter properties are preserved
+    expect(extendedTestCase.tags).toEqual(['@[123],', '@tagOne,', '@tagTwo', '@tagOne', '@tagTwo']);
+    
+    // Verify methods are preserved and work correctly
+    expect(typeof extendedTestCase.ok).toBe('function');
+    expect(extendedTestCase.ok()).toBe(true);
+    
+    expect(typeof extendedTestCase.outcome).toBe('function');
+    expect(extendedTestCase.outcome()).toBe('expected');
+    
+    expect(typeof extendedTestCase.titlePath).toBe('function');
+    expect(extendedTestCase.titlePath()).toEqual(['Suite', 'Nested Suite', 'Test with tags @[123], @tagOne, @tagTwo']);
+    
+    // Verify extended properties are added
+    expect(extendedTestCase.testAlias).toBe('alias-123 - Test with tags');
+    expect(extendedTestCase.testCaseIds).toEqual(['123', '456']);
+  });
+
+  test('_createExtendedTestCase works with testPointMapper function', async () => {
+    // Create a mock TestCase with tags
+    const mockTestCase: TestCase & { _tags: string[]; _grepBaseTitlePath: () => string[] } = {
+      id: 'test-id-with-tags',
+      title: 'Test for configuration mapping',
+      expectedStatus: 'passed',
+      timeout: 30000,
+      annotations: [],
+      retries: 0,
+      repeatEachIndex: 0,
+      results: [],
+      type: 'test' as const,
+      location: { file: '/test/file.spec.ts', line: 20, column: 5 },
+      parent: {} as any,
+      
+      // Mock private properties and methods that the getter uses
+      _tags: ['@tagOne', '@tagTwo'],
+      _grepBaseTitlePath: function() { return [this.title]; },
+      
+      // Mock tags getter that returns configuration tags
+      get tags(): string[] {
+        const titleTags = this._grepBaseTitlePath().join(' ').match(/@[\S]+/g) || [];
+        return [
+          ...titleTags,
+          ...this._tags,
+        ];
+      },
+      
+      ok: function() { return true; },
+      outcome: function() { return 'expected' as const; },
+      titlePath: function() { return ['Suite', this.title]; }
+    };
+
+    // Create reporter instance
+    const reporterOptions = {
+      orgUrl: 'https://dev.azure.com/test',
+      projectName: 'test-project',
+      planId: 123,
+      token: 'test-token',
+      isDisabled: true,
+      // Test the exact testPointMapper from the user's example
+      testPointMapper: async (testCase: TestCase, testPoints: any[]) => {
+        const tag = testCase.tags.map((t: string) => t.toLowerCase());
+        const tagOne = tag.includes("@tagone");
+        const tagTwo = tag.includes("@tagtwo");
+
+        if (tagOne && tagTwo) {
+          return testPoints.filter(
+            (tp) => tp.configuration.id === "3" || tp.configuration.id === "17"
+          );
+        } else if (tagOne) {
+          return testPoints.filter((tp) => tp.configuration.id === "3");
+        } else if (tagTwo) {
+          return testPoints.filter((tp) => tp.configuration.id === "17");
+        } else {
+          throw new Error("invalid test configuration!");
+        }
+      }
+    };
+    
+    const reporter = new AzureDevOpsReporter(reporterOptions);
+    const createExtendedTestCase = (reporter as any)._createExtendedTestCase.bind(reporter);
+    
+    // Create extended test case
+    const extendedTestCase = createExtendedTestCase(mockTestCase, 'alias-test', ['153860', '153875']);
+    
+    // Mock test points
+    const mockTestPoints = [
+      { configuration: { id: "3" }, id: "tp1" },
+      { configuration: { id: "17" }, id: "tp2" },
+      { configuration: { id: "5" }, id: "tp3" }
+    ];
+    
+    // Test that the testPointMapper works with the extended test case
+    const testPointMapper = reporterOptions.testPointMapper;
+    const filteredPoints = await testPointMapper(extendedTestCase, mockTestPoints);
+    
+    // Should return both configuration 3 and 17 since both tagOne and tagTwo are present
+    expect(filteredPoints).toHaveLength(2);
+    expect(filteredPoints.map(tp => tp.configuration.id)).toEqual(["3", "17"]);
+    
+    // Verify that tags property is accessible and works as expected
+    expect(extendedTestCase.tags).toEqual(['@tagOne', '@tagTwo']);
+    
+    // Verify the tag filtering logic works
+    const tag = extendedTestCase.tags.map((t: string) => t.toLowerCase());
+    expect(tag.includes("@tagone")).toBe(true);
+    expect(tag.includes("@tagtwo")).toBe(true);
   });
 });


### PR DESCRIPTION
- Add _createExtendedTestCase helper method to properly preserve all TestCase interface properties
- Explicitly bind methods (ok, outcome, titlePath) to maintain correct 'this' context
- Preserve tags getter by accessing test.tags directly instead of relying on object spread
- Replace object spread in onTestEnd and _publishCaseResult with helper method calls
- Add comprehensive tests for _createExtendedTestCase functionality
- Test testPointMapper integration with preserved tags property
- Update ESLint config to ignore playwright-report directory

Fixes issue where testCase.tags was undefined in testPointMapper due to object spreading not preserving getter properties from the original TestCase interface.

Closes #128