### PR TITLE
feat(reporter): extract test case IDs from annotation descriptions using testCaseIdMatcher

### DIFF
--- a/src/playwright-azure-reporter.ts
+++ b/src/playwright-azure-reporter.ts
@@ -789,8 +789,20 @@ class AzureDevOpsReporter implements Reporter {
         for (const re of this._prepareExtractMatches(this._testCaseIdMatcher)) {
           const matches = obj[key].match(re);
           if (matches && matches.length > 1) {
-            this._logger?.debug(`[_extractMatches] Matches found: ${key} - ${matches[1]}`);
-            matchesResult.push(obj['description']);
+            this._logger?.debug(`[_extractMatches] Matches found in type: ${key} - ${matches[1]}`);
+            // Extract test case IDs from the description using the matcher
+            const description = obj['description'] || '';
+            const descriptionMatches = this._extractMatchesFromText(description);
+            
+            // If the matcher found IDs in the description, use those
+            // Otherwise, fall back to the description itself (original behavior for simple numeric values)
+            if (descriptionMatches.length > 0) {
+              this._logger?.debug(`[_extractMatches] Extracted from description: ${descriptionMatches}`);
+              matchesResult.push(...descriptionMatches);
+            } else {
+              this._logger?.debug(`[_extractMatches] No matches found, using description as-is: ${description}`);
+              matchesResult.push(description);
+            }
           }
         }
       }

--- a/tests/reporter/reporter-testPointMapper.spec.ts
+++ b/tests/reporter/reporter-testPointMapper.spec.ts
@@ -171,7 +171,7 @@ test.describe('TestPointMapper functionality', () => {
     expect(result.output).toContain('"hasTagsProperty":true');
     expect(result.output).toContain('"tagsType":"object"');
     expect(result.output).toContain('"tags":["@tagOne","@tagTwo"]');
-    
+
     // Verify filtering logic worked correctly
     expect(result.output).toContain('TESTPOINTMAPPER_FILTERING:');
     expect(result.output).toContain('"hasTagOne":true');
@@ -292,7 +292,7 @@ test.describe('TestPointMapper functionality', () => {
         test('[3] Test with other tags', { tag: ['@otherTag'] }, async () => {
           expect(1).toBe(1);
         });
-        `
+        `,
       },
       { reporter: '' }
     );
@@ -304,12 +304,12 @@ test.describe('TestPointMapper functionality', () => {
     expect(result.output).toContain('TESTCASE_INFO:');
     expect(result.output).toContain('"hasTagOne":true');
     expect(result.output).toContain('"hasTagTwo":true');
-    
+
     // Verify that tags are properly accessible for all test cases
     expect(result.output).toContain('"allTags":["@tagOne"]');
     expect(result.output).toContain('"allTags":["@tagTwo"]');
     expect(result.output).toContain('"allTags":["@otherTag"]');
-    
+
     // Verify that tags are properly accessible
     expect(result.output).not.toContain('Cannot read properties of undefined');
     expect(result.output).not.toContain('TypeError');
@@ -411,7 +411,7 @@ test.describe('TestPointMapper functionality', () => {
         test('[3] Test with empty tags', { tag: [] }, async () => {
           expect(1).toBe(1);
         });
-        `
+        `,
       },
       { reporter: '' }
     );
@@ -423,7 +423,7 @@ test.describe('TestPointMapper functionality', () => {
     expect(result.output).toContain('EDGE_CASE_TEST:');
     expect(result.output).toContain('SAFE_TAG_ACCESS:');
     expect(result.output).toContain('"tagsIsArray":true');
-    
+
     // Verify no undefined errors in edge cases
     expect(result.output).not.toContain('Cannot read properties of undefined');
     expect(result.output).not.toContain('TypeError');

--- a/tests/reporter/reporter-utils.spec.ts
+++ b/tests/reporter/reporter-utils.spec.ts
@@ -55,7 +55,7 @@ test.describe('Reporter TestCase Extension', () => {
       timeout: 30000,
       annotations: [
         { type: 'slow', description: 'This test is slow' },
-        { type: 'skip', description: 'Skip in CI' }
+        { type: 'skip', description: 'Skip in CI' },
       ],
       retries: 2,
       repeatEachIndex: 0,
@@ -63,24 +63,32 @@ test.describe('Reporter TestCase Extension', () => {
       type: 'test' as const,
       location: { file: '/test/file.spec.ts', line: 10, column: 5 },
       parent: {} as any, // Mock suite
-      
+
       // Mock private properties and methods that the getter uses
       _tags: ['@tagOne', '@tagTwo'],
-      _grepBaseTitlePath: function() { return ['Suite', 'Nested Suite', this.title]; },
-      
+      _grepBaseTitlePath: function () {
+        return ['Suite', 'Nested Suite', this.title];
+      },
+
       // Mock getter: tags (matching actual Playwright implementation)
       get tags(): string[] {
-        const titleTags = this._grepBaseTitlePath().join(' ').match(/@[\S]+/g) || [];
-        return [
-          ...titleTags,
-          ...this._tags,
-        ];
+        const titleTags =
+          this._grepBaseTitlePath()
+            .join(' ')
+            .match(/@[\S]+/g) || [];
+        return [...titleTags, ...this._tags];
       },
-      
+
       // Mock methods
-      ok: function() { return true; },
-      outcome: function() { return 'expected' as const; },
-      titlePath: function() { return ['Suite', 'Nested Suite', this.title]; }
+      ok: function () {
+        return true;
+      },
+      outcome: function () {
+        return 'expected' as const;
+      },
+      titlePath: function () {
+        return ['Suite', 'Nested Suite', this.title];
+      },
     };
 
     // Create a minimal reporter instance to access the private method
@@ -89,20 +97,20 @@ test.describe('Reporter TestCase Extension', () => {
       projectName: 'test-project',
       planId: 123,
       token: 'test-token',
-      isDisabled: true // Disable to avoid actual API calls
+      isDisabled: true, // Disable to avoid actual API calls
     };
-    
+
     const reporter = new AzureDevOpsReporter(reporterOptions);
-    
+
     // Access the private method using type assertion
     const createExtendedTestCase = (reporter as any)._createExtendedTestCase.bind(reporter);
-    
+
     // Test the method
     const testAlias = 'alias-123 - Test with tags';
     const testCaseIds = ['123', '456'];
-    
+
     const extendedTestCase = createExtendedTestCase(mockTestCase, testAlias, testCaseIds);
-    
+
     // Verify all original properties are preserved
     expect(extendedTestCase.id).toBe('test-id-123');
     expect(extendedTestCase.title).toBe('Test with tags @[123], @tagOne, @tagTwo');
@@ -110,27 +118,27 @@ test.describe('Reporter TestCase Extension', () => {
     expect(extendedTestCase.timeout).toBe(30000);
     expect(extendedTestCase.annotations).toEqual([
       { type: 'slow', description: 'This test is slow' },
-      { type: 'skip', description: 'Skip in CI' }
+      { type: 'skip', description: 'Skip in CI' },
     ]);
     expect(extendedTestCase.retries).toBe(2);
     expect(extendedTestCase.repeatEachIndex).toBe(0);
     expect(extendedTestCase.results).toEqual([]);
     expect(extendedTestCase.type).toBe('test');
     expect(extendedTestCase.location).toEqual({ file: '/test/file.spec.ts', line: 10, column: 5 });
-    
+
     // Verify getter properties are preserved
     expect(extendedTestCase.tags).toEqual(['@[123],', '@tagOne,', '@tagTwo', '@tagOne', '@tagTwo']);
-    
+
     // Verify methods are preserved and work correctly
     expect(typeof extendedTestCase.ok).toBe('function');
     expect(extendedTestCase.ok()).toBe(true);
-    
+
     expect(typeof extendedTestCase.outcome).toBe('function');
     expect(extendedTestCase.outcome()).toBe('expected');
-    
+
     expect(typeof extendedTestCase.titlePath).toBe('function');
     expect(extendedTestCase.titlePath()).toEqual(['Suite', 'Nested Suite', 'Test with tags @[123], @tagOne, @tagTwo']);
-    
+
     // Verify extended properties are added
     expect(extendedTestCase.testAlias).toBe('alias-123 - Test with tags');
     expect(extendedTestCase.testCaseIds).toEqual(['123', '456']);
@@ -150,23 +158,31 @@ test.describe('Reporter TestCase Extension', () => {
       type: 'test' as const,
       location: { file: '/test/file.spec.ts', line: 20, column: 5 },
       parent: {} as any,
-      
+
       // Mock private properties and methods that the getter uses
       _tags: ['@tagOne', '@tagTwo'],
-      _grepBaseTitlePath: function() { return [this.title]; },
-      
+      _grepBaseTitlePath: function () {
+        return [this.title];
+      },
+
       // Mock tags getter that returns configuration tags
       get tags(): string[] {
-        const titleTags = this._grepBaseTitlePath().join(' ').match(/@[\S]+/g) || [];
-        return [
-          ...titleTags,
-          ...this._tags,
-        ];
+        const titleTags =
+          this._grepBaseTitlePath()
+            .join(' ')
+            .match(/@[\S]+/g) || [];
+        return [...titleTags, ...this._tags];
       },
-      
-      ok: function() { return true; },
-      outcome: function() { return 'expected' as const; },
-      titlePath: function() { return ['Suite', this.title]; }
+
+      ok: function () {
+        return true;
+      },
+      outcome: function () {
+        return 'expected' as const;
+      },
+      titlePath: function () {
+        return ['Suite', this.title];
+      },
     };
 
     // Create reporter instance
@@ -179,50 +195,48 @@ test.describe('Reporter TestCase Extension', () => {
       // Test the exact testPointMapper from the user's example
       testPointMapper: async (testCase: TestCase, testPoints: any[]) => {
         const tag = testCase.tags.map((t: string) => t.toLowerCase());
-        const tagOne = tag.includes("@tagone");
-        const tagTwo = tag.includes("@tagtwo");
+        const tagOne = tag.includes('@tagone');
+        const tagTwo = tag.includes('@tagtwo');
 
         if (tagOne && tagTwo) {
-          return testPoints.filter(
-            (tp) => tp.configuration.id === "3" || tp.configuration.id === "17"
-          );
+          return testPoints.filter((tp) => tp.configuration.id === '3' || tp.configuration.id === '17');
         } else if (tagOne) {
-          return testPoints.filter((tp) => tp.configuration.id === "3");
+          return testPoints.filter((tp) => tp.configuration.id === '3');
         } else if (tagTwo) {
-          return testPoints.filter((tp) => tp.configuration.id === "17");
+          return testPoints.filter((tp) => tp.configuration.id === '17');
         } else {
-          throw new Error("invalid test configuration!");
+          throw new Error('invalid test configuration!');
         }
-      }
+      },
     };
-    
+
     const reporter = new AzureDevOpsReporter(reporterOptions);
     const createExtendedTestCase = (reporter as any)._createExtendedTestCase.bind(reporter);
-    
+
     // Create extended test case
     const extendedTestCase = createExtendedTestCase(mockTestCase, 'alias-test', ['153860', '153875']);
-    
+
     // Mock test points
     const mockTestPoints = [
-      { configuration: { id: "3" }, id: "tp1" },
-      { configuration: { id: "17" }, id: "tp2" },
-      { configuration: { id: "5" }, id: "tp3" }
+      { configuration: { id: '3' }, id: 'tp1' },
+      { configuration: { id: '17' }, id: 'tp2' },
+      { configuration: { id: '5' }, id: 'tp3' },
     ];
-    
+
     // Test that the testPointMapper works with the extended test case
     const testPointMapper = reporterOptions.testPointMapper;
     const filteredPoints = await testPointMapper(extendedTestCase, mockTestPoints);
-    
+
     // Should return both configuration 3 and 17 since both tagOne and tagTwo are present
     expect(filteredPoints).toHaveLength(2);
-    expect(filteredPoints.map(tp => tp.configuration.id)).toEqual(["3", "17"]);
-    
+    expect(filteredPoints.map((tp) => tp.configuration.id)).toEqual(['3', '17']);
+
     // Verify that tags property is accessible and works as expected
     expect(extendedTestCase.tags).toEqual(['@tagOne', '@tagTwo']);
-    
+
     // Verify the tag filtering logic works
     const tag = extendedTestCase.tags.map((t: string) => t.toLowerCase());
-    expect(tag.includes("@tagone")).toBe(true);
-    expect(tag.includes("@tagtwo")).toBe(true);
+    expect(tag.includes('@tagone')).toBe(true);
+    expect(tag.includes('@tagtwo')).toBe(true);
   });
 });


### PR DESCRIPTION
Enhanced the _extractMatchesFromObject method to apply testCaseIdMatcher regex patterns to annotation descriptions, enabling extraction of test case IDs from complex formats like URLs.

When testCaseIdZone is set to 'annotation', the testCaseIdMatcher now works in two steps:
1. First matcher matches the annotation type (e.g., /(TestCase)/)
2. Additional matchers extract IDs from the description field

This allows users to extract test case IDs from:
- Azure DevOps URLs: https://dev.azure.com/org/project/_workitems/edit/12345
- Custom URL formats with multiple IDs
- Bracketed notation: [12345, 67890]
- Any pattern matchable by regex

The implementation maintains backward compatibility by falling back to the raw description value when no matches are found, preserving existing behavior for simple numeric descriptions.

BREAKING CHANGE: None - fully backward compatible

Closes #132