### PR TITLE
feat(automark): add callback support for storage path and test type

### DIFF
--- a/tests/examples/auto-mark-automated-examples.md
+++ b/tests/examples/auto-mark-automated-examples.md
@@ -53,6 +53,170 @@ autoMarkTestCasesAsAutomated: {
 }
 ```
 
+## Advanced Configuration
+
+### Example 4: Custom Storage Path with Callback Function
+
+Use a callback function to control exactly how the test file path is stored. This is useful for:
+- Creating relative paths instead of absolute paths
+- Avoiding exposure of sensitive information (like usernames) in file paths
+- Ensuring consistent paths across different environments (local, CI/CD)
+
+```typescript
+autoMarkTestCasesAsAutomated: {
+  enabled: true,
+  updateAutomatedTestName: true,
+  updateAutomatedTestStorage: true,
+  automatedTestNameFormat: 'titleWithParent',
+  // Use callback to create relative path from project root
+  automatedTestStoragePath: (testCase) => {
+    const fullPath = testCase.location.file;
+    const parts = fullPath.split('/');
+    
+    // Find project folder and return path relative to it
+    const projectIdx = parts.indexOf('my-project');
+    if (projectIdx >= 0) {
+      return parts.slice(projectIdx + 1).join('/');
+    }
+    
+    // Fallback to just filename
+    return parts[parts.length - 1];
+  }
+}
+```
+
+**Result:** Instead of `/Users/johndoe/projects/my-project/tests/auth.spec.ts`, stores `tests/auth.spec.ts`
+
+### Example 5: Setting Test Type Based on File Location
+
+Use the `automatedTestType` callback to automatically categorize tests:
+
+```typescript
+autoMarkTestCasesAsAutomated: {
+  enabled: true,
+  updateAutomatedTestName: true,
+  updateAutomatedTestStorage: true,
+  // Automatically set test type based on folder structure
+  automatedTestType: (testCase) => {
+    const filePath = testCase.location.file;
+    
+    if (filePath.includes('/e2e/')) return 'End-to-End Test';
+    if (filePath.includes('/integration/')) return 'Integration Test';
+    if (filePath.includes('/unit/')) return 'Unit Test';
+    if (filePath.includes('/api/')) return 'API Test';
+    
+    return 'Functional Test'; // default
+  }
+}
+```
+
+### Example 6: Combining Custom Path and Test Type
+
+```typescript
+autoMarkTestCasesAsAutomated: {
+  enabled: true,
+  updateAutomatedTestName: true,
+  updateAutomatedTestStorage: true,
+  automatedTestNameFormat: 'titleWithParent',
+  // Custom storage path for relative paths
+  automatedTestStoragePath: (testCase) => {
+    const parts = testCase.location.file.split('/');
+    const testsIdx = parts.indexOf('tests');
+    return testsIdx >= 0 ? parts.slice(testsIdx).join('/') : parts[parts.length - 1];
+  },
+  // Custom test type based on file patterns
+  automatedTestType: (testCase) => {
+    const fileName = testCase.location.file;
+    
+    // Check file naming patterns
+    if (fileName.includes('.e2e.')) return 'End-to-End Test';
+    if (fileName.includes('.integration.')) return 'Integration Test';
+    if (fileName.includes('.unit.')) return 'Unit Test';
+    
+    // Check folder structure
+    if (fileName.includes('/e2e/')) return 'End-to-End Test';
+    if (fileName.includes('/integration/')) return 'Integration Test';
+    if (fileName.includes('/unit/')) return 'Unit Test';
+    
+    return 'Functional Test';
+  }
+}
+```
+
+### Example 7: Environment-Specific Configuration
+
+Different settings for different environments:
+
+```typescript
+const isCI = process.env.CI === 'true';
+const isDev = process.env.NODE_ENV === 'development';
+
+autoMarkTestCasesAsAutomated: {
+  enabled: true,
+  updateAutomatedTestName: true,
+  updateAutomatedTestStorage: true,
+  automatedTestNameFormat: 'titleWithParent',
+  // In CI: use relative paths; In dev: use full paths for debugging
+  automatedTestStoragePath: isCI 
+    ? (testCase) => {
+        // CI: relative path
+        const parts = testCase.location.file.split('/');
+        const testsIdx = parts.indexOf('tests');
+        return testsIdx >= 0 ? parts.slice(testsIdx).join('/') : parts[parts.length - 1];
+      }
+    : true, // Dev: full absolute path
+  // Only set test type in CI
+  automatedTestType: isCI
+    ? (testCase) => {
+        const filePath = testCase.location.file;
+        if (filePath.includes('/e2e/')) return 'End-to-End Test';
+        if (filePath.includes('/integration/')) return 'Integration Test';
+        return 'Unit Test';
+      }
+    : undefined
+}
+```
+
+### Example 8: Using Test Case Properties
+
+Access test case properties to make decisions:
+
+```typescript
+autoMarkTestCasesAsAutomated: {
+  enabled: true,
+  updateAutomatedTestName: true,
+  updateAutomatedTestStorage: true,
+  // Use test tags to determine storage format
+  automatedTestStoragePath: (testCase) => {
+    // Check if test has @fullpath tag
+    const hasFullPathTag = testCase.tags.some(tag => tag.includes('@fullpath'));
+    
+    if (hasFullPathTag) {
+      return testCase.location.file; // Full path
+    }
+    
+    // Default: relative path from tests/
+    const parts = testCase.location.file.split('/');
+    const testsIdx = parts.indexOf('tests');
+    return testsIdx >= 0 ? parts.slice(testsIdx).join('/') : parts[parts.length - 1];
+  },
+  // Use test title or tags to determine test type
+  automatedTestType: (testCase) => {
+    const title = testCase.title.toLowerCase();
+    const tags = testCase.tags.map(t => t.toLowerCase());
+    
+    if (tags.some(t => t.includes('@e2e'))) return 'End-to-End Test';
+    if (tags.some(t => t.includes('@integration'))) return 'Integration Test';
+    if (tags.some(t => t.includes('@unit'))) return 'Unit Test';
+    
+    if (title.includes('api')) return 'API Test';
+    if (title.includes('ui')) return 'UI Test';
+    
+    return 'Functional Test';
+  }
+}
+```
+
 ## How It Works
 
 When you run tests with this feature enabled:
@@ -176,7 +340,10 @@ test.describe('Authentication Tests', () => {
 ✅ **Better Visibility** - Teams can see which test cases are automated directly in Azure DevOps  
 ✅ **CI/CD Integration** - Seamlessly integrates with automated pipelines  
 ✅ **Audit Trail** - Azure DevOps tracks who/when automation status was updated  
-✅ **Flexibility** - Control which fields get updated based on your needs
+✅ **Flexibility** - Control which fields get updated based on your needs  
+✅ **Custom Path Logic** - Use callbacks to create relative paths and avoid exposing sensitive information  
+✅ **Test Categorization** - Automatically categorize tests by type using custom logic  
+✅ **Environment-Aware** - Different configurations for local development vs CI/CD
 
 ## Troubleshooting
 
@@ -200,3 +367,77 @@ Verify:
 Ensure your Azure DevOps token or managed identity has:
 - **Work Items (Read & Write)** permission
 - Access to the project containing the test cases
+
+### Callback Function Issues
+
+**Issue:** Custom `automatedTestStoragePath` callback returns undefined or throws errors
+
+**Solutions:**
+1. Always return a string value from the callback
+2. Add error handling to prevent callback failures:
+   ```typescript
+   automatedTestStoragePath: (testCase) => {
+     try {
+       const parts = testCase.location.file.split('/');
+       const idx = parts.indexOf('tests');
+       return idx >= 0 ? parts.slice(idx).join('/') : parts[parts.length - 1];
+     } catch (error) {
+       console.error('Error in automatedTestStoragePath:', error);
+       return testCase.location.file; // Fallback to full path
+     }
+   }
+   ```
+
+**Issue:** `automatedTestType` field not being set in Azure DevOps
+
+**Solutions:**
+1. Ensure the callback returns a non-empty string
+2. Check that the field name is correct: `Microsoft.VSTS.TCM.AutomatedTestType`
+3. Verify your Azure DevOps project supports this field (some custom process templates may not have it)
+4. If the callback returns `''` or a falsy value, the field will not be set (this is by design)
+
+### Callback Best Practices
+
+1. **Always return a value:** Callbacks should always return a string, even if it's a fallback value
+2. **Use try-catch:** Wrap callback logic in try-catch to prevent failures
+3. **Keep it simple:** Complex logic in callbacks can slow down test execution
+4. **Test your callbacks:** Verify callback logic works with different file paths and test structures
+5. **Consider edge cases:** Handle cases where expected folders/patterns don't exist
+
+**Example with error handling:**
+```typescript
+autoMarkTestCasesAsAutomated: {
+  enabled: true,
+  automatedTestStoragePath: (testCase) => {
+    try {
+      if (!testCase.location?.file) return 'unknown.spec.ts';
+      
+      const parts = testCase.location.file.split('/');
+      const testsIdx = parts.indexOf('tests');
+      
+      if (testsIdx >= 0 && testsIdx < parts.length - 1) {
+        return parts.slice(testsIdx).join('/');
+      }
+      
+      return parts[parts.length - 1] || 'unknown.spec.ts';
+    } catch (error) {
+      console.error('Error in automatedTestStoragePath callback:', error);
+      return testCase.location?.file || 'error.spec.ts';
+    }
+  },
+  automatedTestType: (testCase) => {
+    try {
+      const filePath = testCase.location?.file || '';
+      
+      if (filePath.includes('/e2e/')) return 'End-to-End Test';
+      if (filePath.includes('/integration/')) return 'Integration Test';
+      if (filePath.includes('/unit/')) return 'Unit Test';
+      
+      return 'Functional Test';
+    } catch (error) {
+      console.error('Error in automatedTestType callback:', error);
+      return 'Unknown Test';
+    }
+  }
+}
+```

--- a/tests/reporter/reporter-autoMarkTestCasesAsAutomated.spec.ts
+++ b/tests/reporter/reporter-autoMarkTestCasesAsAutomated.spec.ts
@@ -729,7 +729,7 @@ test.describe('Auto-mark test cases as automated feature', () => {
     expect(testNameOp.value).toBe('[1] foobar');
   });
 
-  test('should use full path when automatedTestStorageFullPath is true', async ({ runInlineTest, server }) => {
+  test('should use full path when automatedTestStoragePath is true', async ({ runInlineTest, server }) => {
     const workItemGetRequests: any[] = [];
     const workItemUpdateRequests: any[] = [];
 
@@ -839,7 +839,7 @@ test.describe('Auto-mark test cases as automated feature', () => {
                 enabled: true,
                 updateAutomatedTestName: true,
                 updateAutomatedTestStorage: true,
-                automatedTestStorageFullPath: true,
+                automatedTestStoragePath: true,
               }
             }]
           ]
@@ -874,7 +874,7 @@ test.describe('Auto-mark test cases as automated feature', () => {
     expect(testStorageOp.value).toContain('a.spec.js');
   });
 
-  test('should use basename only when automatedTestStorageFullPath is false (default)', async ({
+  test('should use basename only when automatedTestStoragePath is false (default)', async ({
     runInlineTest,
     server,
   }) => {
@@ -1018,5 +1018,607 @@ test.describe('Auto-mark test cases as automated feature', () => {
     expect(testStorageOp.op).toBe('add');
     // Should only contain the filename, not the path
     expect(testStorageOp.value).toBe('a.spec.js');
+  });
+
+  test('should use custom path when automatedTestStoragePath is a callback function', async ({
+    runInlineTest,
+    server,
+  }) => {
+    const workItemGetRequests: any[] = [];
+    const workItemUpdateRequests: any[] = [];
+
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/wit', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, WORK_ITEM_TRACKING_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_1_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      res.end(
+        JSON.stringify({
+          count: 1,
+          value: [
+            {
+              id: 100000,
+              project: {},
+              outcome: 'Passed',
+              testRun: { id: '150' },
+              priority: 0,
+              url: 'http://localhost/result',
+              lastUpdatedBy: {},
+            },
+          ],
+        })
+      );
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    // Work Item Tracking routes
+    server.setRoute(
+      '/_apis/wit/WorkItems/1?fields=Microsoft.VSTS.TCM.AutomationStatus%2CMicrosoft.VSTS.TCM.AutomatedTestName%2CMicrosoft.VSTS.TCM.AutomatedTestStorage',
+      (req, res) => {
+        workItemGetRequests.push({ id: 1, url: req.url });
+        setHeaders(res, headers);
+        res.end(
+          JSON.stringify({
+            id: 1,
+            fields: {
+              'Microsoft.VSTS.TCM.AutomationStatus': 'Not Automated',
+            },
+          })
+        );
+      }
+    );
+
+    server.setRoute('/_apis/wit/WorkItems/1', async (req, res) => {
+      const body = await getRequestBody(req);
+      workItemUpdateRequests.push(body);
+      setHeaders(res, headers);
+      res.end(JSON.stringify({ id: 1 }));
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testResult',
+              autoMarkTestCasesAsAutomated: {
+                enabled: true,
+                updateAutomatedTestName: true,
+                updateAutomatedTestStorage: true,
+                automatedTestStoragePath: (testCase) => {
+                  // Return relative path from project root
+                  const parts = testCase.location.file.split('/');
+                  const idx = parts.indexOf('tests');
+                  return idx >= 0 ? parts.slice(idx).join('/') : testCase.location.file;
+                },
+              }
+            }]
+          ]
+        };
+      `,
+        'tests/features/a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[1] foobar', async ({}) => {
+          expect(1).toBe(1);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.passed).toBe(1);
+    expect(workItemGetRequests.length).toBe(1);
+    expect(workItemUpdateRequests.length).toBe(1);
+
+    const patchDocument = workItemUpdateRequests[0];
+    expect(Array.isArray(patchDocument)).toBe(true);
+
+    // Check AutomatedTestStorage contains custom relative path
+    const testStorageOp = patchDocument.find(
+      (op: any) => op.path === '/fields/Microsoft.VSTS.TCM.AutomatedTestStorage'
+    );
+    expect(testStorageOp).toBeDefined();
+    expect(testStorageOp.op).toBe('add');
+    // Should contain the relative path from tests/ directory
+    expect(testStorageOp.value).toBe('tests/features/a.spec.js');
+    expect(testStorageOp.value).not.toContain('Users'); // Should not contain absolute path parts
+  });
+
+  test('should set AutomatedTestType when automatedTestType callback is provided', async ({
+    runInlineTest,
+    server,
+  }) => {
+    const workItemGetRequests: any[] = [];
+    const workItemUpdateRequests: any[] = [];
+
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/wit', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, WORK_ITEM_TRACKING_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_1_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      res.end(
+        JSON.stringify({
+          count: 1,
+          value: [
+            {
+              id: 100000,
+              project: {},
+              outcome: 'Passed',
+              testRun: { id: '150' },
+              priority: 0,
+              url: 'http://localhost/result',
+              lastUpdatedBy: {},
+            },
+          ],
+        })
+      );
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    // Work Item Tracking routes
+    server.setRoute(
+      '/_apis/wit/WorkItems/1?fields=Microsoft.VSTS.TCM.AutomationStatus%2CMicrosoft.VSTS.TCM.AutomatedTestName%2CMicrosoft.VSTS.TCM.AutomatedTestStorage',
+      (req, res) => {
+        workItemGetRequests.push({ id: 1, url: req.url });
+        setHeaders(res, headers);
+        res.end(
+          JSON.stringify({
+            id: 1,
+            fields: {
+              'Microsoft.VSTS.TCM.AutomationStatus': 'Not Automated',
+            },
+          })
+        );
+      }
+    );
+
+    server.setRoute('/_apis/wit/WorkItems/1', async (req, res) => {
+      const body = await getRequestBody(req);
+      workItemUpdateRequests.push(body);
+      setHeaders(res, headers);
+      res.end(JSON.stringify({ id: 1 }));
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testResult',
+              autoMarkTestCasesAsAutomated: {
+                enabled: true,
+                updateAutomatedTestName: true,
+                updateAutomatedTestStorage: true,
+                automatedTestType: (testCase) => {
+                  // Set test type based on test file location
+                  if (testCase.location.file.includes('e2e')) {
+                    return 'Unit Test';
+                  }
+                  return 'Integration Test';
+                },
+              }
+            }]
+          ]
+        };
+      `,
+        'tests/features/a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[1] foobar', async ({}) => {
+          expect(1).toBe(1);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.passed).toBe(1);
+    expect(workItemGetRequests.length).toBe(1);
+    expect(workItemUpdateRequests.length).toBe(1);
+
+    const patchDocument = workItemUpdateRequests[0];
+    expect(Array.isArray(patchDocument)).toBe(true);
+
+    // Check AutomatedTestType is set
+    const testTypeOp = patchDocument.find((op: any) => op.path === '/fields/Microsoft.VSTS.TCM.AutomatedTestType');
+    expect(testTypeOp).toBeDefined();
+    expect(testTypeOp.op).toBe('add');
+    expect(testTypeOp.value).toBe('Integration Test'); // File doesn't contain 'e2e'
+  });
+
+  test('should use both custom storage path and test type callbacks together', async ({ runInlineTest, server }) => {
+    const workItemGetRequests: any[] = [];
+    const workItemUpdateRequests: any[] = [];
+
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/wit', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, WORK_ITEM_TRACKING_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_1_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      res.end(
+        JSON.stringify({
+          count: 1,
+          value: [
+            {
+              id: 100000,
+              project: {},
+              outcome: 'Passed',
+              testRun: { id: '150' },
+              priority: 0,
+              url: 'http://localhost/result',
+              lastUpdatedBy: {},
+            },
+          ],
+        })
+      );
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    // Work Item Tracking routes
+    server.setRoute(
+      '/_apis/wit/WorkItems/1?fields=Microsoft.VSTS.TCM.AutomationStatus%2CMicrosoft.VSTS.TCM.AutomatedTestName%2CMicrosoft.VSTS.TCM.AutomatedTestStorage',
+      (req, res) => {
+        workItemGetRequests.push({ id: 1, url: req.url });
+        setHeaders(res, headers);
+        res.end(
+          JSON.stringify({
+            id: 1,
+            fields: {
+              'Microsoft.VSTS.TCM.AutomationStatus': 'Not Automated',
+            },
+          })
+        );
+      }
+    );
+
+    server.setRoute('/_apis/wit/WorkItems/1', async (req, res) => {
+      const body = await getRequestBody(req);
+      workItemUpdateRequests.push(body);
+      setHeaders(res, headers);
+      res.end(JSON.stringify({ id: 1 }));
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testResult',
+              autoMarkTestCasesAsAutomated: {
+                enabled: true,
+                updateAutomatedTestName: true,
+                updateAutomatedTestStorage: true,
+                automatedTestStoragePath: (testCase) => {
+                  // Return project-relative path
+                  const parts = testCase.location.file.split('/');
+                  const projectIdx = parts.indexOf('playwright-azure-reporter');
+                  return projectIdx >= 0 ? parts.slice(projectIdx + 1).join('/') : testCase.location.file;
+                },
+                automatedTestType: (testCase) => {
+                  // Determine test type based on file name
+                  const fileName = testCase.location.file;
+                  if (fileName.includes('.e2e.')) return 'End-to-End Test';
+                  if (fileName.includes('.unit.')) return 'Unit Test';
+                  return 'Functional Test';
+                },
+              }
+            }]
+          ]
+        };
+      `,
+        'tests/features/a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[1] foobar', async ({}) => {
+          expect(1).toBe(1);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.passed).toBe(1);
+    expect(workItemGetRequests.length).toBe(1);
+    expect(workItemUpdateRequests.length).toBe(1);
+
+    const patchDocument = workItemUpdateRequests[0];
+    expect(Array.isArray(patchDocument)).toBe(true);
+
+    // Check both AutomatedTestStorage and AutomatedTestType are set correctly
+    const testStorageOp = patchDocument.find(
+      (op: any) => op.path === '/fields/Microsoft.VSTS.TCM.AutomatedTestStorage'
+    );
+    expect(testStorageOp).toBeDefined();
+    expect(testStorageOp.op).toBe('add');
+    expect(testStorageOp.value).toContain('tests/features/a.spec.js');
+
+    const testTypeOp = patchDocument.find((op: any) => op.path === '/fields/Microsoft.VSTS.TCM.AutomatedTestType');
+    expect(testTypeOp).toBeDefined();
+    expect(testTypeOp.op).toBe('add');
+    expect(testTypeOp.value).toBe('Functional Test'); // No .e2e. or .unit. in filename
+  });
+
+  test('should not set AutomatedTestType when callback returns empty string', async ({ runInlineTest, server }) => {
+    const workItemGetRequests: any[] = [];
+    const workItemUpdateRequests: any[] = [];
+
+    server.setRoute('/_apis/Location', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(location));
+    });
+
+    server.setRoute('/_apis/ResourceAreas', (_, res) => {
+      setHeaders(res, headers);
+      res.end(JSON.stringify(azureAreas(server.PORT)));
+    });
+
+    server.setRoute('/_apis/Test', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, TEST_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/core', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CORE_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/wit', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, WORK_ITEM_TRACKING_OPTIONS_RESPONSE_PATH);
+    });
+
+    server.setRoute('/_apis/projects/SampleSample', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, PROJECT_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, CREATE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Points', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, POINTS_1_RESPONSE_PATH);
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150/Results', (req, res) => {
+      setHeaders(res, headers);
+      res.end(
+        JSON.stringify({
+          count: 1,
+          value: [
+            {
+              id: 100000,
+              project: {},
+              outcome: 'Passed',
+              testRun: { id: '150' },
+              priority: 0,
+              url: 'http://localhost/result',
+              lastUpdatedBy: {},
+            },
+          ],
+        })
+      );
+    });
+
+    server.setRoute('/SampleSample/_apis/test/Runs/150', (req, res) => {
+      setHeaders(res, headers);
+      server.serveFile(req, res, COMPLETE_RUN_VALID_RESPONSE_PATH);
+    });
+
+    // Work Item Tracking routes
+    server.setRoute(
+      '/_apis/wit/WorkItems/1?fields=Microsoft.VSTS.TCM.AutomationStatus%2CMicrosoft.VSTS.TCM.AutomatedTestName%2CMicrosoft.VSTS.TCM.AutomatedTestStorage',
+      (req, res) => {
+        workItemGetRequests.push({ id: 1, url: req.url });
+        setHeaders(res, headers);
+        res.end(
+          JSON.stringify({
+            id: 1,
+            fields: {
+              'Microsoft.VSTS.TCM.AutomationStatus': 'Not Automated',
+            },
+          })
+        );
+      }
+    );
+
+    server.setRoute('/_apis/wit/WorkItems/1', async (req, res) => {
+      const body = await getRequestBody(req);
+      workItemUpdateRequests.push(body);
+      setHeaders(res, headers);
+      res.end(JSON.stringify({ id: 1 }));
+    });
+
+    const result = await runInlineTest(
+      {
+        'playwright.config.ts': `
+        module.exports = {
+          reporter: [
+            ['line'],
+            ['${reporterPath}', { 
+              orgUrl: 'http://localhost:${server.PORT}',
+              projectName: 'SampleSample',
+              planId: 4,
+              token: 'token',
+              logging: true,
+              publishTestResultsMode: 'testResult',
+              autoMarkTestCasesAsAutomated: {
+                enabled: true,
+                updateAutomatedTestName: true,
+                updateAutomatedTestStorage: true,
+                automatedTestType: () => '', // Return empty string
+              }
+            }]
+          ]
+        };
+      `,
+        'tests/features/a.spec.js': `
+        import { test, expect } from '@playwright/test';
+        test('[1] foobar', async ({}) => {
+          expect(1).toBe(1);
+        });
+      `,
+      },
+      { reporter: '' }
+    );
+
+    expect(result.passed).toBe(1);
+    expect(workItemGetRequests.length).toBe(1);
+    expect(workItemUpdateRequests.length).toBe(1);
+
+    const patchDocument = workItemUpdateRequests[0];
+    expect(Array.isArray(patchDocument)).toBe(true);
+
+    // Check AutomatedTestType is NOT set when callback returns empty string
+    const testTypeOp = patchDocument.find((op: any) => op.path === '/fields/Microsoft.VSTS.TCM.AutomatedTestType');
+    expect(testTypeOp).toBeUndefined();
+
+    // But other fields should still be set
+    const testStatusOp = patchDocument.find((op: any) => op.path === '/fields/Microsoft.VSTS.TCM.AutomationStatus');
+    expect(testStatusOp).toBeDefined();
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: Renamed `automatedTestStorageFullPath` to `automatedTestStoragePath` with enhanced functionality

- Replace boolean `automatedTestStorageFullPath` with flexible `automatedTestStoragePath`
  - Supports boolean (false: basename, true: full path) for backward compatibility
  - Supports callback function `(testCase: TestCase) => string` for custom path logic
  - Enables relative paths to avoid exposing sensitive info (usernames) in CI/CD
- Add new `automatedTestType` callback option
  - Sets `Microsoft.VSTS.TCM.AutomatedTestType` field in Azure DevOps
  - Callback signature: `(testCase: TestCase) => string`
  - Field not set if callback returns empty/falsy value
- Update _getAutomatedTestStorage to handle both boolean and function types
- Add 4 comprehensive test cases covering callback scenarios
- Update README and examples with advanced callback usage patterns
- Maintain full backward compatibility with boolean values

Closed #138