### PR TITLE
fix(ci): fix changelog generation and GitHub Release notes in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,17 +57,16 @@ jobs:
         run: |
           if [ -f ".beta-release.json" ]; then
             echo "Configuration file found"
-            # Use stable release configuration if available, otherwise use defaults
             ENABLED=$(jq -r '.stableRelease.enabled // true' .beta-release.json)
             VERSION_STRATEGY=$(jq -r '.stableRelease.versionStrategy // "patch"' .beta-release.json)
             PUBLISH_TAG=$(jq -r '.stableRelease.publishTag // "latest"' .beta-release.json)
             CREATE_GITHUB_RELEASE=$(jq -r '.stableRelease.createGitHubRelease // true' .beta-release.json)
-            
+
             echo "enabled=$ENABLED" >> $GITHUB_OUTPUT
             echo "version-strategy=$VERSION_STRATEGY" >> $GITHUB_OUTPUT
             echo "publish-tag=$PUBLISH_TAG" >> $GITHUB_OUTPUT
             echo "create-github-release=$CREATE_GITHUB_RELEASE" >> $GITHUB_OUTPUT
-            
+
             echo "Stable release enabled: $ENABLED"
             echo "Version strategy: $VERSION_STRATEGY"
             echo "Publish tag: $PUBLISH_TAG"
@@ -97,59 +96,98 @@ jobs:
       - name: Build project
         run: yarn build
 
-      - name: Generate release version
+      - name: Calculate version
         id: version
-        if: github.event_name == 'workflow_dispatch'
         run: |
-          # Get current version
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          echo "Current version: $CURRENT_VERSION"
+          STRATEGY="${{ github.event.inputs.version_strategy || steps.config.outputs.version-strategy }}"
 
-          VERSION_STRATEGY="${{ github.event.inputs.version_strategy || steps.config.outputs.version-strategy }}"
-          echo "Version strategy: $VERSION_STRATEGY"
+          # Get latest stable release tag from git (source of truth)
+          LATEST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v '\-' | head -1)
 
-          # Parse version and increment based on strategy
-          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
-          MAJOR=${VERSION_PARTS[0]}
-          MINOR=${VERSION_PARTS[1]}
-          PATCH=${VERSION_PARTS[2]%%-*}  # Remove any pre-release suffix
+          if [ -z "$LATEST" ]; then
+            MAJOR=0; MINOR=1; PATCH=0
+          else
+            BASE=$(echo "$LATEST" | sed 's/^v//')
+            MAJOR=$(echo "$BASE" | cut -d. -f1)
+            MINOR=$(echo "$BASE" | cut -d. -f2)
+            PATCH=$(echo "$BASE" | cut -d. -f3)
+          fi
 
-          case $VERSION_STRATEGY in
-            "major")
-              NEW_MAJOR=$((MAJOR + 1))
-              NEW_VERSION="$NEW_MAJOR.0.0"
-              ;;
-            "minor")
-              NEW_MINOR=$((MINOR + 1))
-              NEW_VERSION="$MAJOR.$NEW_MINOR.0"
-              ;;
-            *)
-              NEW_PATCH=$((PATCH + 1))
-              NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
-              ;;
+          case "$STRATEGY" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
           esac
 
-          echo "New version: $NEW_VERSION"
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
           echo "new-version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "previous=${LATEST:-none}" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION (was: ${LATEST:-none}, strategy: $STRATEGY)"
 
-          # Update package.json version (skip scripts to avoid duplicate changelog generation)
+          # Update package.json version
           npm version "$NEW_VERSION" --no-git-tag-version --ignore-scripts
 
-      - name: Update changelog
-        if: github.event_name == 'workflow_dispatch'
+      - name: Generate changelog
+        id: changelog
         run: |
-          # Generate changelog for the new release version
-          npx conventional-changelog -p angular -i CHANGELOG.md -s
+          PREV="${{ steps.version.outputs.previous }}"
+          VERSION="v${{ steps.version.outputs.new-version }}"
+
+          if [ "$PREV" = "none" ]; then
+            RANGE="HEAD"
+          else
+            RANGE="${PREV}..HEAD"
+          fi
+
+          echo "## ${VERSION}" > /tmp/changelog-entry.md
+          echo "" >> /tmp/changelog-entry.md
+          echo "Released: $(date -u +%Y-%m-%d)" >> /tmp/changelog-entry.md
+          echo "" >> /tmp/changelog-entry.md
+
+          # Features
+          FEATS=$(git log "$RANGE" --pretty=format:'- %s (%h)' --grep='^feat' --no-merges 2>/dev/null || true)
+          if [ -n "$FEATS" ]; then
+            echo "### Features" >> /tmp/changelog-entry.md
+            echo "$FEATS" >> /tmp/changelog-entry.md
+            echo "" >> /tmp/changelog-entry.md
+          fi
+
+          # Bug fixes
+          FIXES=$(git log "$RANGE" --pretty=format:'- %s (%h)' --grep='^fix' --no-merges 2>/dev/null || true)
+          if [ -n "$FIXES" ]; then
+            echo "### Bug Fixes" >> /tmp/changelog-entry.md
+            echo "$FIXES" >> /tmp/changelog-entry.md
+            echo "" >> /tmp/changelog-entry.md
+          fi
+
+          # Other changes (chore, refactor, docs, etc.) — exclude feat/fix, limit to 20
+          OTHER=$(git log "$RANGE" --pretty=format:'- %s (%h)' --no-merges --invert-grep --grep='^feat' --grep='^fix' 2>/dev/null | head -20 || true)
+          if [ -n "$OTHER" ]; then
+            echo "### Other Changes" >> /tmp/changelog-entry.md
+            echo "$OTHER" >> /tmp/changelog-entry.md
+            echo "" >> /tmp/changelog-entry.md
+          fi
+
+          # Prepend new entry to CHANGELOG.md
+          if [ -f CHANGELOG.md ]; then
+            cat /tmp/changelog-entry.md CHANGELOG.md > /tmp/changelog-full.md
+            mv /tmp/changelog-full.md CHANGELOG.md
+          else
+            echo "# Changelog" > CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            cat /tmp/changelog-entry.md >> CHANGELOG.md
+          fi
+
+          # Save release notes for GitHub release step
+          cp /tmp/changelog-entry.md /tmp/release-notes.md
 
       - name: Commit version changes
-        if: github.event_name == 'workflow_dispatch' && steps.version.outputs.new-version
         run: |
           git add package.json CHANGELOG.md
           git commit -m "chore: release v${{ steps.version.outputs.new-version }}"
-          git tag "v${{ steps.version.outputs.new-version }}"
+          git tag -a "v${{ steps.version.outputs.new-version }}" -m "Release v${{ steps.version.outputs.new-version }}"
 
       - name: Push changes
-        if: github.event_name == 'workflow_dispatch' && steps.version.outputs.new-version
         run: |
           git push origin main
           git push origin "v${{ steps.version.outputs.new-version }}"
@@ -163,40 +201,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
-        if: steps.config.outputs.create-github-release == 'true' && steps.version.outputs.new-version
+        if: steps.config.outputs.create-github-release == 'true'
         run: |
           RELEASE_VERSION="${{ steps.version.outputs.new-version }}"
-
-          # Extract changelog content for the current version
-          CHANGELOG_CONTENT=""
-          if [ -f "CHANGELOG.md" ]; then
-            # Extract the content between the first version header and the next one
-            CHANGELOG_CONTENT=$(awk "/^## \[${RELEASE_VERSION}\]/ {flag=1; next} /^## \[/ && flag {flag=0} flag {print}" CHANGELOG.md || echo "")
-            
-            # If that doesn't work, try extracting the latest version's content
-            if [ -z "$CHANGELOG_CONTENT" ]; then
-              CHANGELOG_CONTENT=$(awk '/^## \[/ {if(first++) exit} first {print}' CHANGELOG.md | tail -n +2 || echo "")
-            fi
-          fi
-
-          # Create release description
-          RELEASE_NOTES="🎉 **Release $RELEASE_VERSION**
-
-            This is a stable release.
-
-            **Installation:**
-            \`\`\`bash
-            npm install @alex_neo/playwright-azure-reporter@${{ steps.config.outputs.publish-tag }}
-            \`\`\`"
-
-          # Add changelog content if available
-          if [ ! -z "$CHANGELOG_CONTENT" ]; then
-            RELEASE_NOTES="$RELEASE_NOTES
-
-            ## Changes
-
-            $CHANGELOG_CONTENT"
-          fi
+          RELEASE_NOTES=$(cat /tmp/release-notes.md)
 
           gh release create "v$RELEASE_VERSION" \
             --title "Release v$RELEASE_VERSION" \


### PR DESCRIPTION
Closes #145

## Summary

- Replace `npx conventional-changelog` with direct `git log "$PREV..HEAD"` — correct commit range, correct ordering
- Derive version from latest git tag instead of `package.json` (source of truth)
- Track previous tag and pass it to the changelog step to define the exact commit range
- Save release notes to `/tmp/release-notes.md` during generation; read it directly in the GitHub Release step instead of `awk`-parsing `CHANGELOG.md`
- Use annotated tag (`git tag -a -m`) instead of lightweight tag

## Test plan

- [ ] Trigger `workflow_dispatch` with `patch` strategy and verify CHANGELOG.md only contains commits since the last tag
- [ ] Verify commits appear in correct reverse-chronological order grouped by feat / fix / other
- [ ] Verify GitHub Release notes match exactly the new changelog entry
- [ ] Verify git tag is annotated
